### PR TITLE
Rename Artifact Ids. Fixes #33

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -2,9 +2,9 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.redhat.lightblue.client</groupId>
-    <artifactId>client-pom</artifactId>
+    <artifactId>lightblue-client-pom</artifactId>
     <version>1.2.0-SNAPSHOT</version>
   </parent>
-  <artifactId>core</artifactId>
+  <artifactId>lightblue-client-core</artifactId>
   <name>lightblue-client: ${project.groupId}|${project.artifactId}</name>
 </project>

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -2,15 +2,15 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.redhat.lightblue.client</groupId>
-    <artifactId>client-pom</artifactId>
+    <artifactId>lightblue-client-pom</artifactId>
     <version>1.2.0-SNAPSHOT</version>
   </parent>
-  <artifactId>http</artifactId>
+  <artifactId>lightblue-client-http</artifactId>
   <name>lightblue-client: ${project.groupId}|${project.artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>com.redhat.lightblue.client</groupId>
-      <artifactId>core</artifactId>
+      <artifactId>lightblue-client-core</artifactId>
       <version>${project.version}</version>
       <type>jar</type>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <version>7</version>
     </parent>
     <groupId>com.redhat.lightblue.client</groupId>
-    <artifactId>client-pom</artifactId>
+    <artifactId>lightblue-client-pom</artifactId>
     <version>1.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>lightblue-client: ${project.groupId}|${project.artifactId}</name>


### PR DESCRIPTION
This makes them follow the convention most projects use, and makes it
less confusing to reason about when looking at dependency JARs in an IDE
or a build.

core -> lightblue-client-core, http -> lightblue-client-http
