### PR TITLE
release input stream when done reading

### DIFF
--- a/core/src/main/java/com/redhat/lightblue/client/PropertiesLightblueClientConfiguration.java
+++ b/core/src/main/java/com/redhat/lightblue/client/PropertiesLightblueClientConfiguration.java
@@ -106,8 +106,8 @@ public final class PropertiesLightblueClientConfiguration {
      *         process.
      */
     public static LightblueClientConfiguration fromPath(Path pathToProperties) {
-        try {
-            return fromInputStream(Files.newInputStream(pathToProperties));
+        try(InputStream inStream = Files.newInputStream(pathToProperties)) {
+            return fromInputStream(inStream);
         } catch (IOException e) {
             LOGGER.error(pathToProperties + " could not be found/read", e);
             throw new LightblueClientConfigurationException("Could not read properties file from " +


### PR DESCRIPTION
I was getting a bunch of these exceptions while testing the migrator. This change will ensure that the InputStream is closed when it is finished being read in.

```
[ConsistencyCheckerRunner] ERROR com.redhat.lightblue.client.PropertiesLightblueClientConfiguration - /usr/share/migrator/lightblue-client.properties could not be found/read
java.nio.file.FileSystemException: /usr/share/migrator/lightblue-client.properties: Too many open files
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:91)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
	at sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:214)
	at java.nio.file.Files.newByteChannel(Files.java:317)
	at java.nio.file.Files.newByteChannel(Files.java:363)
	at java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:380)
	at java.nio.file.Files.newInputStream(Files.java:108)
	at com.redhat.lightblue.client.PropertiesLightblueClientConfiguration.fromPath(PropertiesLightblueClientConfiguration.java:110)
	at com.redhat.lightblue.client.http.LightblueHttpClient.<init>(LightblueHttpClient.java:65)
	at com.redhat.lightblue.migrator.consistency.ConsistencyChecker.run(ConsistencyChecker.java:119)
	at java.lang.Thread.run(Thread.java:745)
Exception in thread "ConsistencyCheckerRunner" com.redhat.lightblue.client.LightblueClientConfigurationException: Could not read properties file from path, /usr/share/migrator/lightblue-client.properties
	at com.redhat.lightblue.client.PropertiesLightblueClientConfiguration.fromPath(PropertiesLightblueClientConfiguration.java:113)
	at com.redhat.lightblue.client.http.LightblueHttpClient.<init>(LightblueHttpClient.java:65)
	at com.redhat.lightblue.migrator.consistency.ConsistencyChecker.run(ConsistencyChecker.java:119)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.nio.file.FileSystemException: /usr/share/migrator/lightblue-client.properties: Too many open files
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:91)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
	at sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:214)
	at java.nio.file.Files.newByteChannel(Files.java:317)
	at java.nio.file.Files.newByteChannel(Files.java:363)
	at java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:380)
	at java.nio.file.Files.newInputStream(Files.java:108)
	at com.redhat.lightblue.client.PropertiesLightblueClientConfiguration.fromPath(PropertiesLightblueClientConfiguration.java:110)
	... 3 more
```