### PR TITLE
return null instead of throwing an exception if no processed result is returned

### DIFF
--- a/http/src/test/java/com/redhat/lightblue/client/http/LightblueHttpClientTest.java
+++ b/http/src/test/java/com/redhat/lightblue/client/http/LightblueHttpClientTest.java
@@ -33,6 +33,51 @@ public class LightblueHttpClientTest {
         .equals(results[0]));
     }
 
+    @Test
+    public void testPojoMapping_EmptyProcessed_ForArrayGeneric() throws IOException {
+        DataFindRequest findRequest = new DataFindRequest("foo", "bar");
+
+        findRequest.where(withValue("foo = bar"));
+        findRequest.select(includeField("_id"));
+
+        client.setLightblueResponse("{\"matchCount\": 0, \"modifiedCount\": 0, \"processed\": [], \"status\": \"COMPLETE\"}");
+
+        SimpleModelObject[] results = client.data(findRequest,
+                SimpleModelObject[].class);
+
+        Assert.assertEquals(0, results.length);
+    }
+
+    @Test
+    public void testPojoMapping_EmptyProcessed_ForSimpleGeneric() throws IOException {
+        DataFindRequest findRequest = new DataFindRequest("foo", "bar");
+
+        findRequest.where(withValue("foo = bar"));
+        findRequest.select(includeField("_id"));
+
+        client.setLightblueResponse("{\"matchCount\": 0, \"modifiedCount\": 0, \"processed\": [], \"status\": \"COMPLETE\"}");
+
+        SimpleModelObject results = client.data(findRequest,
+                SimpleModelObject.class);
+
+        Assert.assertNull(results);
+    }
+
+    @Test
+    public void testPojoMapping_NullProcessedNode() throws IOException {
+        DataFindRequest findRequest = new DataFindRequest("foo", "bar");
+
+        findRequest.where(withValue("foo = bar"));
+        findRequest.select(includeField("_id"));
+
+        client.setLightblueResponse("{\"matchCount\": 0, \"modifiedCount\": 0, \"processed\": null, \"status\": \"COMPLETE\"}");
+
+        SimpleModelObject results = client.data(findRequest,
+                SimpleModelObject.class);
+
+        Assert.assertNull(results);
+    }
+
     @Test(expected = LightblueHttpClientException.class)
     public void testPojoMappingWithParsingError() throws IOException {
         DataFindRequest findRequest = new DataFindRequest("foo", "bar");


### PR DESCRIPTION
It is annoying to get an exception for an empty result set.