### PR TITLE
throw an exception if errors are returned from lb

### DIFF
--- a/core/src/main/java/com/redhat/lightblue/client/response/LightblueErrorResponseException.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/LightblueErrorResponseException.java
@@ -1,0 +1,24 @@
+package com.redhat.lightblue.client.response;
+
+/**
+ * Exception thrown when an error status is returned from Lightblue.
+ *
+ * @author dcrissman
+ */
+public class LightblueErrorResponseException extends RuntimeException {
+
+    private static final long serialVersionUID = -3732433923527169586L;
+
+    public LightblueErrorResponseException(String message) {
+        super(message);
+    }
+
+    public LightblueErrorResponseException(Throwable cause) {
+        super(cause);
+    }
+
+    public LightblueErrorResponseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/core/src/main/java/com/redhat/lightblue/client/response/LightblueResponse.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/LightblueResponse.java
@@ -95,6 +95,10 @@ public class LightblueResponse {
     @SuppressWarnings("unchecked")
     public <T> T parseProcessed(final Class<T> type)
             throws LightblueResponseParseException {
+        if (hasError()) {
+            throw new LightblueErrorResponseException("Error returned in response: " + getText());
+        }
+
         try {
             JsonNode processedNode = json.path("processed");
 
@@ -111,7 +115,7 @@ public class LightblueResponse {
 
             return mapper.readValue(processedNode.traverse(), type);
         } catch (RuntimeException | IOException e) {
-            throw new LightblueResponseParseException("Error parsing lightblue response: " + json.toString() + "\n", e);
+            throw new LightblueResponseParseException("Error parsing lightblue response: " + getText() + "\n", e);
         }
     }
 

--- a/core/src/test/java/com/redhat/lightblue/client/response/TestLightblueResponse.java
+++ b/core/src/test/java/com/redhat/lightblue/client/response/TestLightblueResponse.java
@@ -30,7 +30,7 @@ public class TestLightblueResponse {
         new LightblueResponse("bad json");
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = NullPointerException.class)
     public void testConstructor_NullObjectMapper() {
         ObjectMapper om = null;
         new LightblueResponse(om);

--- a/core/src/test/java/com/redhat/lightblue/client/response/TestLightblueResponse.java
+++ b/core/src/test/java/com/redhat/lightblue/client/response/TestLightblueResponse.java
@@ -25,6 +25,17 @@ public class TestLightblueResponse {
         testResponse = new LightblueResponse(initialResponseText);
     }
 
+    @Test(expected = RuntimeException.class)
+    public void testConstructor_BadJson() {
+        new LightblueResponse("bad json");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testConstructor_NullObjectMapper() {
+        ObjectMapper om = null;
+        new LightblueResponse(om);
+    }
+
     @Test
     public void testGetText() {
         Assert.assertEquals(initialResponseText, testResponse.getText());
@@ -60,6 +71,11 @@ public class TestLightblueResponse {
     public void testHasError_True() {
         LightblueResponse response = new LightblueResponse("{\"status\":\"error\"}");
         assertTrue(response.hasError());
+    }
+
+    @Test(expected = LightblueErrorResponseException.class)
+    public void testParseProcessed_LightblueReturnsError() throws LightblueResponseParseException {
+        new LightblueResponse("{\"status\":\"error\", \"errors\":[{\"errorCode\": \"metadata:InvalidFieldReference\"}]}").parseProcessed(Object.class);
     }
 
     @Test


### PR DESCRIPTION
This will create a uniformed way for client application code to deal with errors when they are returned from lb.