### PR TITLE
Removing create(Collection<Object> objects) apis because they are covered by create(Object... objects)

### DIFF
--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataInsertRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataInsertRequest.java
@@ -29,11 +29,12 @@ public class DataInsertRequest extends AbstractLightblueDataRequest {
     }
 
     public void create(Object... objects){
-        this.objects = objects;
-    }
-
-    public void create(Collection<Object> objects){
-        this.objects = objects.toArray(new Object[objects.size()]);
+        if (objects[0] instanceof java.util.Collection<?>) {
+            this.objects = ((Collection<?>)objects[0]).toArray();
+        }
+        else {
+            this.objects = objects;
+        }
     }
 
     @Override

--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataSaveRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataSaveRequest.java
@@ -30,11 +30,12 @@ public class DataSaveRequest extends AbstractLightblueDataRequest {
     }
 
     public void create(Object... objects){
-        this.objects = objects;
-    }
-
-    public void create(Collection<Object> objects){
-        this.objects = objects.toArray(new Object[objects.size()]);
+        if (objects[0] instanceof java.util.Collection<?>) {
+            this.objects = ((Collection<?>)objects[0]).toArray();
+        }
+        else {
+            this.objects = objects;
+        }
     }
 
     public Boolean isUpsert() {


### PR DESCRIPTION
This caused collections of objects to be processed as single objects, resulting in incorrect lightblue request being generated.