### PR TITLE
fixes #65 - standardizes the default ObjectMapper

### DIFF
--- a/core/src/main/java/com/redhat/lightblue/client/json/LightBlueJsonHelperImpl.java
+++ b/core/src/main/java/com/redhat/lightblue/client/json/LightBlueJsonHelperImpl.java
@@ -3,33 +3,28 @@ package com.redhat.lightblue.client.json;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.lightblue.client.util.JSON;
 
 public class LightBlueJsonHelperImpl implements LightBlueJsonHelper {
-    public Map<String, Object> getJsonMap(String json) {
 
+    @Override
+    public Map<String, Object> getJsonMap(String json) {
         HashMap<String, Object> result = null;
-        JsonFactory factory = new JsonFactory();
-        ObjectMapper mapper = new ObjectMapper(factory);
-        TypeReference<HashMap<String, Object>> typeRef
-                = new TypeReference<HashMap<String, Object>>() {
-                };
+        TypeReference<HashMap<String, Object>> typeRef = new TypeReference<HashMap<String, Object>>() {};
 
         try {
-            result = mapper.readValue(json, typeRef);
+            result = JSON.getDefaultObjectMapper().readValue(json, typeRef);
         } catch (Exception e) {
             e.printStackTrace();
         }
 
         return result;
-
     }
 
     @Override
     public String createEntityPutRequestJson(String entity, String version,
-                                             Map<String, Object> data) {
+            Map<String, Object> data) {
 
         return null;
     }

--- a/core/src/main/java/com/redhat/lightblue/client/response/LightblueResponse.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/LightblueResponse.java
@@ -3,24 +3,12 @@ package com.redhat.lightblue.client.response;
 import java.io.IOException;
 import java.lang.reflect.Array;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.redhat.lightblue.client.util.ClientConstants;
+import com.redhat.lightblue.client.util.JSON;
 
 public class LightblueResponse {
-
-    /**
-     * It is safe and encouraged to share the same mapper among threads. It is
-     * thread safe. So, this default instance is static.
-     *
-     * @see <a href="http://stackoverflow.com/a/3909846">The developer of the
-     * Jackson library's own quote.</a>
-     */
-    public static final ObjectMapper DEFAULT_MAPPER = new ObjectMapper()
-            .setDateFormat(ClientConstants.getDateFormat())
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     private String text;
     private JsonNode json;
@@ -34,11 +22,11 @@ public class LightblueResponse {
     }
 
     public LightblueResponse() {
-        this(DEFAULT_MAPPER);
+        this(JSON.getDefaultObjectMapper());
     }
 
     public LightblueResponse(String responseText) {
-        this(responseText, DEFAULT_MAPPER);
+        this(responseText, JSON.getDefaultObjectMapper());
     }
 
     public LightblueResponse(String responseText, ObjectMapper mapper) {

--- a/core/src/main/java/com/redhat/lightblue/client/util/ClientConstants.java
+++ b/core/src/main/java/com/redhat/lightblue/client/util/ClientConstants.java
@@ -4,7 +4,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.TimeZone;
 
-public class ClientConstants {
+public final class ClientConstants {
     private static final DateFormat DATE_FORMAT;
     private static final String DATE_FORMAT_STR = "yyyyMMdd'T'HH:mm:ss.SSSZ";
 
@@ -20,5 +20,7 @@ public class ClientConstants {
     public static DateFormat getDateFormat() {
         return (DateFormat) DATE_FORMAT.clone();
     }
+
+    private ClientConstants() {}
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/util/JSON.java
+++ b/core/src/main/java/com/redhat/lightblue/client/util/JSON.java
@@ -3,9 +3,9 @@ package com.redhat.lightblue.client.util;
 import java.io.IOException;
 import java.io.StringWriter;
 
-import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -14,13 +14,40 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author mpatercz
  *
  */
-public abstract class JSON {
+public final class JSON {
 
-    private static ObjectMapper mapper = new ObjectMapper();
-    private static JsonFactory jf = new JsonFactory();
+    /**
+     * It is safe and encouraged to share the same mapper among threads. It is
+     * thread safe. So, this default instance is static.
+     *
+     * @see <a href="http://stackoverflow.com/a/3909846">The developer of the
+     * Jackson library's own quote.</a>
+     */
+    private static final ObjectMapper DEFAULT_MAPPER = new ObjectMapper()
+            .setDateFormat(ClientConstants.getDateFormat())
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
-    static {
-        mapper.setDateFormat(ClientConstants.getDateFormat());
+    private static ObjectMapper objectMapper;
+
+    /**
+     * <p>Sets the default {@link ObjectMapper} that will be used throughout
+     * the lightblue-client unless otherwise not specified.</p>
+     * <p>This is an optional setter, in that if not set a prepared
+     * default is already available.</p>
+     * @param m
+     */
+    public static void setDefaultObjectMapper(ObjectMapper m) {
+        objectMapper = m;
+    }
+
+    /**
+     * @return default {@link ObjectMapper}.
+     */
+    public static ObjectMapper getDefaultObjectMapper() {
+        if (objectMapper == null) {
+            return DEFAULT_MAPPER;
+        }
+        return objectMapper;
     }
 
     /**
@@ -32,8 +59,9 @@ public abstract class JSON {
      */
     public static String toJson(Object obj) {
         StringWriter sw = new StringWriter();
+        ObjectMapper mapper = getDefaultObjectMapper();
         try {
-            JsonGenerator jg = jf.createGenerator(sw);
+            JsonGenerator jg = mapper.getFactory().createGenerator(sw);
             mapper.writeValue(jg, obj);
         } catch (JsonMappingException e) {
             e.printStackTrace();
@@ -44,5 +72,7 @@ public abstract class JSON {
         }
         return sw.toString();
     }
+
+    private JSON() {}
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/response/TestLightblueResponse.java
+++ b/core/src/test/java/com/redhat/lightblue/client/response/TestLightblueResponse.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.lightblue.client.util.JSON;
 
 public class TestLightblueResponse {
 
@@ -49,7 +50,7 @@ public class TestLightblueResponse {
 
     @Test
     public void testSetJson() throws JsonProcessingException, IOException {
-        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper mapper = JSON.getDefaultObjectMapper();
         JsonNode node = mapper.readTree(updatedResponseText);
 
         testResponse.setJson(node);

--- a/http/src/main/java/com/redhat/lightblue/client/http/LightblueHttpClient.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/LightblueHttpClient.java
@@ -24,6 +24,7 @@ import com.redhat.lightblue.client.http.request.LightblueHttpMetadataRequest;
 import com.redhat.lightblue.client.request.LightblueRequest;
 import com.redhat.lightblue.client.response.LightblueResponse;
 import com.redhat.lightblue.client.response.LightblueResponseParseException;
+import com.redhat.lightblue.client.util.JSON;
 
 public class LightblueHttpClient implements LightblueClient {
     private final LightblueClientConfiguration configuration;
@@ -55,7 +56,7 @@ public class LightblueHttpClient implements LightblueClient {
      * This constructor will use a copy of specified configuration object.
      */
     public LightblueHttpClient(LightblueClientConfiguration configuration) {
-        this(configuration, LightblueResponse.DEFAULT_MAPPER);
+        this(configuration, JSON.getDefaultObjectMapper());
     }
 
     /**
@@ -92,7 +93,7 @@ public class LightblueHttpClient implements LightblueClient {
         configuration.setMetadataServiceURI(metadataServiceURI);
         configuration.setUseCertAuth(useCertAuth);
 
-        this.mapper = LightblueResponse.DEFAULT_MAPPER;
+        this.mapper = JSON.getDefaultObjectMapper();
     }
 
     /*


### PR DESCRIPTION
Centralize on a standard default ObjectMapper and allow that to be changed if desired by the client.