### PR TITLE
Use enums over string constants

### DIFF
--- a/core/src/main/java/com/redhat/lightblue/client/request/AbstractLightblueDataRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/AbstractLightblueDataRequest.java
@@ -2,12 +2,24 @@ package com.redhat.lightblue.client.request;
 
 import org.apache.commons.lang.StringUtils;
 
-public abstract class AbstractLightblueDataRequest extends AbstractLightblueRequest implements LightblueRequest {
-    public static final String PATH_PARAM_INSERT = "";
-    public static final String PATH_PARAM_SAVE = "save";
-    public static final String PATH_PARAM_UPDATE = "update";
-    public static final String PATH_PARAM_DELETE = "delete";
-    public static final String PATH_PARAM_FIND = "find";
+public abstract class AbstractLightblueDataRequest extends AbstractLightblueRequest {
+    public enum Operation {
+        INSERT(""),
+        SAVE("save"),
+        UPDATE("update"),
+        DELETE("delete"),
+        FIND("find");
+
+        private final String pathParam;
+
+        public String getPathParam() {
+            return pathParam;
+        }
+
+        private Operation(String pathParam) {
+            this.pathParam = pathParam;
+        }
+    }
 
     @Override
     public String getRestURI(String baseServiceURI) {

--- a/core/src/main/java/com/redhat/lightblue/client/request/AbstractLightblueDataRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/AbstractLightblueDataRequest.java
@@ -21,6 +21,13 @@ public abstract class AbstractLightblueDataRequest extends AbstractLightblueRequ
         }
     }
 
+    public abstract Operation getOperation();
+
+    @Override
+    public String getOperationPathParam() {
+        return getOperation().getPathParam();
+    }
+
     @Override
     public String getRestURI(String baseServiceURI) {
         StringBuilder requestURI = new StringBuilder();

--- a/core/src/main/java/com/redhat/lightblue/client/request/AbstractLightblueDataRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/AbstractLightblueDataRequest.java
@@ -3,7 +3,7 @@ package com.redhat.lightblue.client.request;
 import org.apache.commons.lang.StringUtils;
 
 public abstract class AbstractLightblueDataRequest extends AbstractLightblueRequest {
-    public enum Operation {
+    public enum DataOperation {
         INSERT(""),
         SAVE("save"),
         UPDATE("update"),
@@ -16,12 +16,12 @@ public abstract class AbstractLightblueDataRequest extends AbstractLightblueRequ
             return pathParam;
         }
 
-        private Operation(String pathParam) {
+        private DataOperation(String pathParam) {
             this.pathParam = pathParam;
         }
     }
 
-    public abstract Operation getOperation();
+    public abstract DataOperation getOperation();
 
     @Override
     public String getOperationPathParam() {

--- a/core/src/main/java/com/redhat/lightblue/client/request/AbstractLightblueMetadataRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/AbstractLightblueMetadataRequest.java
@@ -3,18 +3,37 @@ package com.redhat.lightblue.client.request;
 import org.apache.commons.lang.StringUtils;
 
 public abstract class AbstractLightblueMetadataRequest extends AbstractLightblueRequest implements LightblueRequest {
-    public static final String PATH_PARAM_GET_ENTITY_NAMES = "";
-    public static final String PATH_PARAM_GET_ENTITY_VERSIONS = "";
-    public static final String PATH_PARAM_GET_ENTITY_METADATA = "";
-    public static final String PATH_PARAM_GET_ENTITY_DEPENDENCIES = "dependencies";
-    public static final String PATH_PARAM_GET_ENTITY_ROLES = "roles";
-    public static final String PATH_PARAM_CREATE_METADATA = "";
-    public static final String PATH_PARAM_CREATE_SCHEMA = "";
-    public static final String PATH_PARAM_UPDATE_SCHEMA_STATUS = "";
-    public static final String PATH_PARAM_UPDATE_ENTITY_INFO = "";
-    public static final String PATH_PARAM_SET_DEFAULT_VERSION = "default";
-    public static final String PATH_PARAM_REMOVE_ENTITY = "";
-    public static final String PATH_PARAM_CLEAR_DEFAULT_VERSION = "";
+    public enum MetadataOperation {
+        GET_ENTITY_NAMES(""),
+        GET_ENTITY_VERSIONS(""),
+        GET_ENTITY_METADATA(""),
+        GET_ENTITY_DEPENDENCIES("dependencies"),
+        GET_ENTITY_ROLES("roles"),
+        CREATE_METADATA(""),
+        CREATE_SCHEMA(""),
+        UPDATE_SCHEMA_STATUS(""),
+        UPDATE_ENTITY_INFO(""),
+        SET_DEFAULT_VERSION("default"),
+        REMOVE_ENTITY(""),
+        CLEAR_DEFAULT_VERSION("");
+
+        private final String pathParam;
+
+        public String getPathParam() {
+            return pathParam;
+        }
+
+        private MetadataOperation(String pathParam) {
+            this.pathParam = pathParam;
+        }
+    }
+
+    public abstract MetadataOperation getOperation();
+
+    @Override
+    public String getOperationPathParam() {
+        return getOperation().getPathParam();
+    }
 
     @Override
     public String getRestURI(String baseServiceURI) {

--- a/core/src/main/java/com/redhat/lightblue/client/request/AbstractLightblueRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/AbstractLightblueRequest.java
@@ -4,9 +4,9 @@ import org.apache.commons.lang.StringUtils;
 
 public abstract class AbstractLightblueRequest implements LightblueRequest {
 
-    static String PATH_SEPARATOR = "/";
-    protected static String PATH_PARAM_ENTITY = "entity";
-    protected static String PATH_PARAM_VERSION = "version";
+    protected static final String PATH_SEPARATOR = "/";
+    protected static final String PATH_PARAM_ENTITY = "entity";
+    protected static final String PATH_PARAM_VERSION = "version";
 
     private String entityName;
     private String entityVersion;

--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataDeleteRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataDeleteRequest.java
@@ -30,6 +30,6 @@ public class DataDeleteRequest extends AbstractLightblueDataRequest {
 
     @Override
     public String getOperationPathParam() {
-        return PATH_PARAM_DELETE;
+        return Operation.DELETE.getPathParam();
     }
 }

--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataDeleteRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataDeleteRequest.java
@@ -20,8 +20,8 @@ public class DataDeleteRequest extends AbstractLightblueDataRequest {
     }
 
     @Override
-    public Operation getOperation() {
-        return Operation.DELETE;
+    public DataOperation getOperation() {
+        return DataOperation.DELETE;
     }
 
     @Override

--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataDeleteRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataDeleteRequest.java
@@ -20,6 +20,11 @@ public class DataDeleteRequest extends AbstractLightblueDataRequest {
     }
 
     @Override
+    public Operation getOperation() {
+        return Operation.DELETE;
+    }
+
+    @Override
     public String getBody() {
         StringBuilder sb = new StringBuilder();
         sb.append("{\"query\":");
@@ -28,8 +33,4 @@ public class DataDeleteRequest extends AbstractLightblueDataRequest {
         return sb.toString();
     }
 
-    @Override
-    public String getOperationPathParam() {
-        return Operation.DELETE.getPathParam();
-    }
 }

--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataFindRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataFindRequest.java
@@ -93,6 +93,6 @@ public class DataFindRequest extends AbstractLightblueDataRequest {
 
     @Override
     public String getOperationPathParam() {
-        return PATH_PARAM_FIND;
+        return Operation.FIND.getPathParam();
     }
 }

--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataFindRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataFindRequest.java
@@ -55,8 +55,8 @@ public class DataFindRequest extends AbstractLightblueDataRequest {
     }
 
     @Override
-    public Operation getOperation() {
-        return Operation.FIND;
+    public DataOperation getOperation() {
+        return DataOperation.FIND;
     }
 
     @Override

--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataFindRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataFindRequest.java
@@ -55,6 +55,11 @@ public class DataFindRequest extends AbstractLightblueDataRequest {
     }
 
     @Override
+    public Operation getOperation() {
+        return Operation.FIND;
+    }
+
+    @Override
     public String getBody() {
         StringBuilder sb = new StringBuilder();
         sb.append("{\"query\":");
@@ -91,8 +96,4 @@ public class DataFindRequest extends AbstractLightblueDataRequest {
         return sb.toString();
     }
 
-    @Override
-    public String getOperationPathParam() {
-        return Operation.FIND.getPathParam();
-    }
 }

--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataInsertRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataInsertRequest.java
@@ -60,6 +60,6 @@ public class DataInsertRequest extends AbstractLightblueDataRequest {
 
     @Override
     public String getOperationPathParam() {
-        return PATH_PARAM_INSERT;
+        return Operation.INSERT.getPathParam();
     }
 }

--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataInsertRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataInsertRequest.java
@@ -37,6 +37,11 @@ public class DataInsertRequest extends AbstractLightblueDataRequest {
     }
 
     @Override
+    public Operation getOperation() {
+        return Operation.INSERT;
+    }
+
+    @Override
     public String getBody() {
         StringBuilder sb = new StringBuilder();
         sb.append("{\"data\":[");
@@ -58,8 +63,4 @@ public class DataInsertRequest extends AbstractLightblueDataRequest {
         return sb.toString();
     }
 
-    @Override
-    public String getOperationPathParam() {
-        return Operation.INSERT.getPathParam();
-    }
 }

--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataInsertRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataInsertRequest.java
@@ -37,8 +37,8 @@ public class DataInsertRequest extends AbstractLightblueDataRequest {
     }
 
     @Override
-    public Operation getOperation() {
-        return Operation.INSERT;
+    public DataOperation getOperation() {
+        return DataOperation.INSERT;
     }
 
     @Override

--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataSaveRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataSaveRequest.java
@@ -47,7 +47,7 @@ public class DataSaveRequest extends AbstractLightblueDataRequest {
 
     @Override
     public String getOperationPathParam() {
-        return PATH_PARAM_SAVE;
+        return Operation.SAVE.getPathParam();
     }
 
     @Override

--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataSaveRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataSaveRequest.java
@@ -46,8 +46,8 @@ public class DataSaveRequest extends AbstractLightblueDataRequest {
     }
 
     @Override
-    public String getOperationPathParam() {
-        return Operation.SAVE.getPathParam();
+    public Operation getOperation() {
+        return Operation.SAVE;
     }
 
     @Override

--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataSaveRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataSaveRequest.java
@@ -46,8 +46,8 @@ public class DataSaveRequest extends AbstractLightblueDataRequest {
     }
 
     @Override
-    public Operation getOperation() {
-        return Operation.SAVE;
+    public DataOperation getOperation() {
+        return DataOperation.SAVE;
     }
 
     @Override

--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataUpdateRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataUpdateRequest.java
@@ -97,7 +97,7 @@ public class DataUpdateRequest extends AbstractLightblueDataRequest {
 
     @Override
     public String getOperationPathParam() {
-        return PATH_PARAM_UPDATE;
+        return Operation.UPDATE.getPathParam();
     }
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataUpdateRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataUpdateRequest.java
@@ -63,6 +63,11 @@ public class DataUpdateRequest extends AbstractLightblueDataRequest {
     }
 
     @Override
+    public Operation getOperation() {
+        return Operation.UPDATE;
+    }
+
+    @Override
     public String getBody() {
         // http://jewzaam.gitbooks.io/lightblue-specifications/content/language_specification/data.html#update
         StringBuilder sb = new StringBuilder();
@@ -93,11 +98,6 @@ public class DataUpdateRequest extends AbstractLightblueDataRequest {
         sb.append("}");
 
         return sb.toString();
-    }
-
-    @Override
-    public String getOperationPathParam() {
-        return Operation.UPDATE.getPathParam();
     }
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataUpdateRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataUpdateRequest.java
@@ -63,8 +63,8 @@ public class DataUpdateRequest extends AbstractLightblueDataRequest {
     }
 
     @Override
-    public Operation getOperation() {
-        return Operation.UPDATE;
+    public DataOperation getOperation() {
+        return DataOperation.UPDATE;
     }
 
     @Override

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataClearDefaultVersionRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataClearDefaultVersionRequest.java
@@ -14,8 +14,8 @@ public class MetadataClearDefaultVersionRequest extends AbstractLightblueMetadat
     }
 
     @Override
-    public String getOperationPathParam() {
-        return PATH_PARAM_CLEAR_DEFAULT_VERSION;
+    public MetadataOperation getOperation() {
+        return MetadataOperation.CLEAR_DEFAULT_VERSION;
     }
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataCreateRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataCreateRequest.java
@@ -14,8 +14,8 @@ public class MetadataCreateRequest extends AbstractLightblueMetadataRequest {
     }
 
     @Override
-    public String getOperationPathParam() {
-        return PATH_PARAM_CREATE_METADATA;
+    public MetadataOperation getOperation() {
+        return MetadataOperation.CREATE_METADATA;
     }
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataCreateSchemaRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataCreateSchemaRequest.java
@@ -14,8 +14,8 @@ public class MetadataCreateSchemaRequest extends AbstractLightblueMetadataReques
     }
 
     @Override
-    public String getOperationPathParam() {
-        return PATH_PARAM_CREATE_SCHEMA;
+    public MetadataOperation getOperation() {
+        return MetadataOperation.CREATE_SCHEMA;
     }
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataGetEntityDependenciesRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataGetEntityDependenciesRequest.java
@@ -14,8 +14,8 @@ public class MetadataGetEntityDependenciesRequest extends AbstractLightblueMetad
     }
 
     @Override
-    public String getOperationPathParam() {
-        return PATH_PARAM_GET_ENTITY_DEPENDENCIES;
+    public MetadataOperation getOperation() {
+        return MetadataOperation.GET_ENTITY_DEPENDENCIES;
     }
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataGetEntityMetadataRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataGetEntityMetadataRequest.java
@@ -14,8 +14,8 @@ public class MetadataGetEntityMetadataRequest extends AbstractLightblueMetadataR
     }
 
     @Override
-    public String getOperationPathParam() {
-        return PATH_PARAM_GET_ENTITY_METADATA;
+    public MetadataOperation getOperation() {
+        return MetadataOperation.GET_ENTITY_METADATA;
     }
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataGetEntityNamesRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataGetEntityNamesRequest.java
@@ -14,8 +14,8 @@ public class MetadataGetEntityNamesRequest extends AbstractLightblueMetadataRequ
     }
 
     @Override
-    public String getOperationPathParam() {
-        return PATH_PARAM_GET_ENTITY_NAMES;
+    public MetadataOperation getOperation() {
+        return MetadataOperation.GET_ENTITY_NAMES;
     }
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataGetEntityRolesRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataGetEntityRolesRequest.java
@@ -14,8 +14,8 @@ public class MetadataGetEntityRolesRequest extends AbstractLightblueMetadataRequ
     }
 
     @Override
-    public String getOperationPathParam() {
-        return PATH_PARAM_GET_ENTITY_ROLES;
+    public MetadataOperation getOperation() {
+        return MetadataOperation.GET_ENTITY_ROLES;
     }
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataGetEntityVersionsRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataGetEntityVersionsRequest.java
@@ -14,8 +14,8 @@ public class MetadataGetEntityVersionsRequest extends AbstractLightblueMetadataR
     }
 
     @Override
-    public String getOperationPathParam() {
-        return PATH_PARAM_GET_ENTITY_VERSIONS;
+    public MetadataOperation getOperation() {
+        return MetadataOperation.GET_ENTITY_VERSIONS;
     }
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataRemoveEntityRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataRemoveEntityRequest.java
@@ -14,8 +14,8 @@ public class MetadataRemoveEntityRequest extends AbstractLightblueMetadataReques
     }
 
     @Override
-    public String getOperationPathParam() {
-        return PATH_PARAM_REMOVE_ENTITY;
+    public MetadataOperation getOperation() {
+        return MetadataOperation.REMOVE_ENTITY;
     }
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataSetDefaultVersionRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataSetDefaultVersionRequest.java
@@ -14,8 +14,8 @@ public class MetadataSetDefaultVersionRequest extends AbstractLightblueMetadataR
     }
 
     @Override
-    public String getOperationPathParam() {
-        return PATH_PARAM_SET_DEFAULT_VERSION;
+    public MetadataOperation getOperation() {
+        return MetadataOperation.SET_DEFAULT_VERSION;
     }
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataUpdateEntityInfoRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataUpdateEntityInfoRequest.java
@@ -14,8 +14,8 @@ public class MetadataUpdateEntityInfoRequest extends AbstractLightblueMetadataRe
     }
 
     @Override
-    public String getOperationPathParam() {
-        return PATH_PARAM_UPDATE_ENTITY_INFO;
+    public MetadataOperation getOperation() {
+        return MetadataOperation.UPDATE_ENTITY_INFO;
     }
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataUpdateSchemaStatusRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataUpdateSchemaStatusRequest.java
@@ -14,8 +14,8 @@ public class MetadataUpdateSchemaStatusRequest extends AbstractLightblueMetadata
     }
 
     @Override
-    public String getOperationPathParam() {
-        return PATH_PARAM_UPDATE_SCHEMA_STATUS;
+    public MetadataOperation getOperation() {
+        return MetadataOperation.UPDATE_SCHEMA_STATUS;
     }
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/request/AbstractLightblueRequestTest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/AbstractLightblueRequestTest.java
@@ -1,15 +1,16 @@
 package com.redhat.lightblue.client.request;
 
+import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.Operation;
 
 public class AbstractLightblueRequestTest {
 
-	protected static final String entityName = "lightblueEntity";
-	protected static final String entityVersion = "1.2.3";
-	protected static final String body = "{\"name\":\"value\"}";
-	protected static final String baseURI = "http://lightblue.io/rest/";
-	protected static final String dataOperation = "dosomethingwithdata";
-	protected static final String metadataOperation = "dosomethingwithmetadata";
-	protected static final String finalDataURI = baseURI + dataOperation + "/" + entityName + "/" + entityVersion;
-	protected static final String finalMetadataURI = baseURI + entityName + "/" + entityVersion + "/" + metadataOperation;
-	
+    protected static final String entityName = "lightblueEntity";
+    protected static final String entityVersion = "1.2.3";
+    protected static final String body = "{\"name\":\"value\"}";
+    protected static final String baseURI = "http://lightblue.io/rest/";
+    protected static final Operation dataOperation = Operation.FIND;
+    protected static final String metadataOperation = "dosomethingwithmetadata";
+    protected static final String finalDataURI = baseURI + dataOperation.getPathParam() + "/" + entityName + "/" + entityVersion;
+    protected static final String finalMetadataURI = baseURI + entityName + "/" + entityVersion + "/" + metadataOperation;
+
 }

--- a/core/src/test/java/com/redhat/lightblue/client/request/AbstractLightblueRequestTest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/AbstractLightblueRequestTest.java
@@ -1,6 +1,6 @@
 package com.redhat.lightblue.client.request;
 
-import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.Operation;
+import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.DataOperation;
 
 public class AbstractLightblueRequestTest {
 
@@ -8,7 +8,7 @@ public class AbstractLightblueRequestTest {
     protected static final String entityVersion = "1.2.3";
     protected static final String body = "{\"name\":\"value\"}";
     protected static final String baseURI = "http://lightblue.io/rest/";
-    protected static final Operation dataOperation = Operation.FIND;
+    protected static final DataOperation dataOperation = DataOperation.FIND;
     protected static final String metadataOperation = "dosomethingwithmetadata";
     protected static final String finalDataURI = baseURI + dataOperation.getPathParam() + "/" + entityName + "/" + entityVersion;
     protected static final String finalMetadataURI = baseURI + entityName + "/" + entityVersion + "/" + metadataOperation;

--- a/core/src/test/java/com/redhat/lightblue/client/request/AbstractLightblueRequestTest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/AbstractLightblueRequestTest.java
@@ -1,6 +1,7 @@
 package com.redhat.lightblue.client.request;
 
 import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.DataOperation;
+import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest.MetadataOperation;
 
 public class AbstractLightblueRequestTest {
 
@@ -9,8 +10,8 @@ public class AbstractLightblueRequestTest {
     protected static final String body = "{\"name\":\"value\"}";
     protected static final String baseURI = "http://lightblue.io/rest/";
     protected static final DataOperation dataOperation = DataOperation.FIND;
-    protected static final String metadataOperation = "dosomethingwithmetadata";
+    protected static final MetadataOperation metadataOperation = MetadataOperation.GET_ENTITY_DEPENDENCIES;
     protected static final String finalDataURI = baseURI + dataOperation.getPathParam() + "/" + entityName + "/" + entityVersion;
-    protected static final String finalMetadataURI = baseURI + entityName + "/" + entityVersion + "/" + metadataOperation;
+    protected static final String finalMetadataURI = baseURI + entityName + "/" + entityVersion + "/" + metadataOperation.getPathParam();
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/request/TestAbstractLightblueDataRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/TestAbstractLightblueDataRequest.java
@@ -9,7 +9,7 @@ public class TestAbstractLightblueDataRequest extends AbstractLightblueRequestTe
     AbstractLightblueDataRequest testRequest = new AbstractLightblueDataRequest() {
 
         @Override
-        public Operation getOperation() {
+        public DataOperation getOperation() {
             return dataOperation;
         }
 

--- a/core/src/test/java/com/redhat/lightblue/client/request/TestAbstractLightblueDataRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/TestAbstractLightblueDataRequest.java
@@ -6,24 +6,30 @@ import org.junit.Test;
 
 public class TestAbstractLightblueDataRequest extends AbstractLightblueRequestTest {
 
-		
-	AbstractLightblueDataRequest testRequest = new AbstractLightblueDataRequest() {
+    AbstractLightblueDataRequest testRequest = new AbstractLightblueDataRequest() {
 
-		@Override
-    public String getOperationPathParam() {
-	    return dataOperation;
+        @Override
+        public Operation getOperation() {
+            return dataOperation;
+        }
+
+        @Override
+        public String getBody() {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+    };
+
+    @Before
+    public void setUp() throws Exception {
+        testRequest.setEntityName(entityName);
+        testRequest.setEntityVersion(entityVersion);
     }
-	};
-		
-	@Before
-	public void setUp() throws Exception {
-		testRequest.setEntityName(entityName);
-		testRequest.setEntityVersion(entityVersion);
-	}
 
-	@Test
-	public void testGetRestURI() {
-		Assert.assertEquals(finalDataURI, testRequest.getRestURI(baseURI));
-	}
+    @Test
+    public void testGetRestURI() {
+        Assert.assertEquals(finalDataURI, testRequest.getRestURI(baseURI));
+    }
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/request/TestAbstractLightblueMetadataRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/TestAbstractLightblueMetadataRequest.java
@@ -6,23 +6,23 @@ import org.junit.Test;
 
 public class TestAbstractLightblueMetadataRequest extends AbstractLightblueRequestTest {
 
-	AbstractLightblueMetadataRequest testRequest = new AbstractLightblueMetadataRequest() {
+    AbstractLightblueMetadataRequest testRequest = new AbstractLightblueMetadataRequest() {
 
-		@Override
-		public String getOperationPathParam() {
-			return metadataOperation;
-		}
-	};
+        @Override
+        public MetadataOperation getOperation() {
+            return metadataOperation;
+        }
+    };
 
-	@Before
-	public void setUp() throws Exception {
-		testRequest.setEntityName(entityName);
-		testRequest.setEntityVersion(entityVersion);
-	}
+    @Before
+    public void setUp() throws Exception {
+        testRequest.setEntityName(entityName);
+        testRequest.setEntityVersion(entityVersion);
+    }
 
-	@Test
-	public void testGetRestURI() {
-		Assert.assertEquals(finalMetadataURI, testRequest.getRestURI(baseURI));
-	}
+    @Test
+    public void testGetRestURI() {
+        Assert.assertEquals(finalMetadataURI, testRequest.getRestURI(baseURI));
+    }
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/request/data/TestDataDeleteRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/data/TestDataDeleteRequest.java
@@ -1,33 +1,35 @@
 package com.redhat.lightblue.client.request.data;
 
-import com.redhat.lightblue.client.expression.query.Query;
 import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 import org.skyscreamer.jsonassert.JSONAssert;
+
+import com.redhat.lightblue.client.expression.query.Query;
+import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.Operation;
+import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 
 public class TestDataDeleteRequest extends AbstractLightblueRequestTest {
 
-    private Query testQueryExpression = new Query() {
+    private final Query testQueryExpression = new Query() {
+        @Override
         public String toJson() {
             return "{\"field1\":\"test\",\"op\":\"$ne\",\"rValue\":\"hack\"}";
         }
     };
 
-	DataDeleteRequest request = new DataDeleteRequest();
+    DataDeleteRequest request = new DataDeleteRequest();
 
-	@Before
-	public void setUp() throws Exception {
-		request = new DataDeleteRequest(entityName, entityVersion);
-	}
+    @Before
+    public void setUp() throws Exception {
+        request = new DataDeleteRequest(entityName, entityVersion);
+    }
 
-	@Test
-	public void testGetOperationPathParam() {
-		Assert.assertEquals(DataDeleteRequest.PATH_PARAM_DELETE, request.getOperationPathParam());
-	}
+    @Test
+    public void testGetOperationPathParam() {
+        Assert.assertEquals(Operation.DELETE.getPathParam(), request.getOperationPathParam());
+    }
 
     @Test
     public void testRequestWithExpressionFormsProperBody() throws JSONException {

--- a/core/src/test/java/com/redhat/lightblue/client/request/data/TestDataDeleteRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/data/TestDataDeleteRequest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import com.redhat.lightblue.client.expression.query.Query;
-import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.Operation;
+import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.DataOperation;
 import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 
 public class TestDataDeleteRequest extends AbstractLightblueRequestTest {
@@ -28,7 +28,7 @@ public class TestDataDeleteRequest extends AbstractLightblueRequestTest {
 
     @Test
     public void testGetOperationPathParam() {
-        Assert.assertEquals(Operation.DELETE.getPathParam(), request.getOperationPathParam());
+        Assert.assertEquals(DataOperation.DELETE.getPathParam(), request.getOperationPathParam());
     }
 
     @Test

--- a/core/src/test/java/com/redhat/lightblue/client/request/data/TestDataFindRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/data/TestDataFindRequest.java
@@ -1,54 +1,58 @@
 package com.redhat.lightblue.client.request.data;
 
-import com.redhat.lightblue.client.enums.SortDirection;
-import com.redhat.lightblue.client.expression.query.Query;
-import com.redhat.lightblue.client.projection.Projection;
-import com.redhat.lightblue.client.request.SortCondition;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.redhat.lightblue.client.enums.SortDirection;
+import com.redhat.lightblue.client.expression.query.Query;
+import com.redhat.lightblue.client.projection.Projection;
+import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.Operation;
+import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
+import com.redhat.lightblue.client.request.SortCondition;
 
-public class TestDataFindRequest extends AbstractLightblueRequestTest  {
+public class TestDataFindRequest extends AbstractLightblueRequestTest {
 
-    private Query testQueryExpression = new Query() {
+    private final Query testQueryExpression = new Query() {
+        @Override
         public String toJson() {
             return "{\"field1\":\"test\",\"op\":\"$ne\",\"rValue\":\"hack\"}";
         }
     };
 
-    private Projection testProjection1 = new Projection () {
+    private final Projection testProjection1 = new Projection() {
+        @Override
         public String toJson() {
             return "{\"field1\":\"name\"}";
         }
     };
 
-    private Projection testProjection2 = new Projection() {
+    private final Projection testProjection2 = new Projection() {
+        @Override
         public String toJson() {
             return "{\"field2\":\"address\"}";
         }
     };
 
-    private SortCondition sortCondition1 = new SortCondition("field1", SortDirection.ASC);
-    private SortCondition sortCondition2 = new SortCondition("field2", SortDirection.DESC);
+    private final SortCondition sortCondition1 = new SortCondition("field1", SortDirection.ASC);
+    private final SortCondition sortCondition2 = new SortCondition("field2", SortDirection.DESC);
 
-	DataFindRequest request = new DataFindRequest();
+    DataFindRequest request = new DataFindRequest();
 
-	@Before
-	public void setUp() throws Exception {
-		request = new DataFindRequest(entityName, entityVersion);
-	}
+    @Before
+    public void setUp() throws Exception {
+        request = new DataFindRequest(entityName, entityVersion);
+    }
 
-	@Test
-	public void testGetOperationPathParam() {
-		Assert.assertEquals(DataFindRequest.PATH_PARAM_FIND, request.getOperationPathParam());
-	}
+    @Test
+    public void testGetOperationPathParam() {
+        Assert.assertEquals(Operation.FIND.getPathParam(), request.getOperationPathParam());
+    }
 
     @Test
     public void testRequestWithExpressionAndSingleProjectionFormsProperBody() throws JSONException {

--- a/core/src/test/java/com/redhat/lightblue/client/request/data/TestDataFindRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/data/TestDataFindRequest.java
@@ -12,7 +12,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import com.redhat.lightblue.client.enums.SortDirection;
 import com.redhat.lightblue.client.expression.query.Query;
 import com.redhat.lightblue.client.projection.Projection;
-import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.Operation;
+import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.DataOperation;
 import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 import com.redhat.lightblue.client.request.SortCondition;
 
@@ -51,7 +51,7 @@ public class TestDataFindRequest extends AbstractLightblueRequestTest {
 
     @Test
     public void testGetOperationPathParam() {
-        Assert.assertEquals(Operation.FIND.getPathParam(), request.getOperationPathParam());
+        Assert.assertEquals(DataOperation.FIND.getPathParam(), request.getOperationPathParam());
     }
 
     @Test

--- a/core/src/test/java/com/redhat/lightblue/client/request/data/TestDataInsertRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/data/TestDataInsertRequest.java
@@ -1,50 +1,54 @@
 package com.redhat.lightblue.client.request.data;
 
-import com.redhat.lightblue.client.projection.Projection;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.redhat.lightblue.client.projection.Projection;
+import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.Operation;
+import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 
 public class TestDataInsertRequest extends AbstractLightblueRequestTest {
 
     private class TestObj {
         public String field1 = "field1Test";
         public String field2 = "field2Test";
+
         public String toJson() {
             return "{\"field1\":\"" + field1 + "\",\"field2\":\"" + field2 + "\"}";
         }
     }
 
-    private Projection testProjection1 = new Projection () {
+    private final Projection testProjection1 = new Projection() {
+        @Override
         public String toJson() {
             return "{\"field1\":\"name\"}";
         }
     };
 
-    private Projection testProjection2 = new Projection() {
+    private final Projection testProjection2 = new Projection() {
+        @Override
         public String toJson() {
             return "{\"field2\":\"address\"}";
         }
     };
 
-	DataInsertRequest request = new DataInsertRequest();
-	
-	@Before
-	public void setUp() throws Exception {
-		request = new DataInsertRequest(entityName, entityVersion);
-	}
+    DataInsertRequest request = new DataInsertRequest();
 
-	@Test
-	public void testGetOperationPathParam() {
-		Assert.assertEquals(DataInsertRequest.PATH_PARAM_INSERT, request.getOperationPathParam());
-	}
+    @Before
+    public void setUp() throws Exception {
+        request = new DataInsertRequest(entityName, entityVersion);
+    }
+
+    @Test
+    public void testGetOperationPathParam() {
+        Assert.assertEquals(Operation.INSERT.getPathParam(), request.getOperationPathParam());
+    }
 
     @Test
     public void testRequestWithExpressionAndSingleProjectionFormsProperBody() throws JSONException {
@@ -92,7 +96,7 @@ public class TestDataInsertRequest extends AbstractLightblueRequestTest {
         request.returns(projections);
         TestObj obj1 = new TestObj();
         TestObj obj2 = new TestObj();
-        request.create(obj1,obj2);
+        request.create(obj1, obj2);
 
         String expected = "{\"data\":[" + obj1.toJson() + "," + obj2.toJson() + "],\"projection\":[" + testProjection1.toJson() + "," + testProjection2.toJson() + "]}";
 

--- a/core/src/test/java/com/redhat/lightblue/client/request/data/TestDataInsertRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/data/TestDataInsertRequest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import com.redhat.lightblue.client.projection.Projection;
-import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.Operation;
+import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.DataOperation;
 import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 
 public class TestDataInsertRequest extends AbstractLightblueRequestTest {
@@ -47,7 +47,7 @@ public class TestDataInsertRequest extends AbstractLightblueRequestTest {
 
     @Test
     public void testGetOperationPathParam() {
-        Assert.assertEquals(Operation.INSERT.getPathParam(), request.getOperationPathParam());
+        Assert.assertEquals(DataOperation.INSERT.getPathParam(), request.getOperationPathParam());
     }
 
     @Test

--- a/core/src/test/java/com/redhat/lightblue/client/request/data/TestDataSaveRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/data/TestDataSaveRequest.java
@@ -1,50 +1,54 @@
 package com.redhat.lightblue.client.request.data;
 
-import com.redhat.lightblue.client.projection.Projection;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.redhat.lightblue.client.projection.Projection;
+import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.Operation;
+import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 
 public class TestDataSaveRequest extends AbstractLightblueRequestTest {
 
     private class TestObj {
         public String field1 = "field1Test";
         public String field2 = "field2Test";
+
         public String toJson() {
             return "{\"field1\":\"" + field1 + "\",\"field2\":\"" + field2 + "\"}";
         }
     }
 
-    private Projection testProjection1 = new Projection () {
+    private final Projection testProjection1 = new Projection() {
+        @Override
         public String toJson() {
             return "{\"field1\":\"name\"}";
         }
     };
 
-    private Projection testProjection2 = new Projection() {
+    private final Projection testProjection2 = new Projection() {
+        @Override
         public String toJson() {
             return "{\"field2\":\"address\"}";
         }
     };
 
-	DataSaveRequest request = new DataSaveRequest();
+    DataSaveRequest request = new DataSaveRequest();
 
-	@Before
-	public void setUp() throws Exception {
-		request = new DataSaveRequest(entityName, entityVersion);
-	}
+    @Before
+    public void setUp() throws Exception {
+        request = new DataSaveRequest(entityName, entityVersion);
+    }
 
-	@Test
-	public void testGetOperationPathParam() {
-		Assert.assertEquals(DataSaveRequest.PATH_PARAM_SAVE, request.getOperationPathParam());
-	}
+    @Test
+    public void testGetOperationPathParam() {
+        Assert.assertEquals(Operation.SAVE.getPathParam(), request.getOperationPathParam());
+    }
 
     @Test
     public void testRequestWithSingleProjectionFormsProperBody() throws JSONException {
@@ -104,7 +108,7 @@ public class TestDataSaveRequest extends AbstractLightblueRequestTest {
         request.returns(projections);
         TestObj obj1 = new TestObj();
         TestObj obj2 = new TestObj();
-        request.create(obj1,obj2);
+        request.create(obj1, obj2);
 
         String expected = "{\"data\":[" + obj1.toJson() + "," + obj2.toJson() + "],\"projection\":[" + testProjection1.toJson() + "," + testProjection2.toJson() + "]}";
 

--- a/core/src/test/java/com/redhat/lightblue/client/request/data/TestDataSaveRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/data/TestDataSaveRequest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import com.redhat.lightblue.client.projection.Projection;
-import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.Operation;
+import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.DataOperation;
 import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 
 public class TestDataSaveRequest extends AbstractLightblueRequestTest {
@@ -47,7 +47,7 @@ public class TestDataSaveRequest extends AbstractLightblueRequestTest {
 
     @Test
     public void testGetOperationPathParam() {
-        Assert.assertEquals(Operation.SAVE.getPathParam(), request.getOperationPathParam());
+        Assert.assertEquals(DataOperation.SAVE.getPathParam(), request.getOperationPathParam());
     }
 
     @Test

--- a/core/src/test/java/com/redhat/lightblue/client/request/data/TestDataUpdateRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/data/TestDataUpdateRequest.java
@@ -5,19 +5,20 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
+import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.Operation;
 
 public class TestDataUpdateRequest extends AbstractLightblueRequestTest {
 
-	DataUpdateRequest request = new DataUpdateRequest();
-	
-	@Before
-	public void setUp() throws Exception {
-		request = new DataUpdateRequest(entityName, entityVersion);
-	}
-	
-	@Test
-	public void testGetOperationPathParam() {
-		Assert.assertEquals(DataUpdateRequest.PATH_PARAM_UPDATE, request.getOperationPathParam());
-	}
+    DataUpdateRequest request = new DataUpdateRequest();
+
+    @Before
+    public void setUp() throws Exception {
+        request = new DataUpdateRequest(entityName, entityVersion);
+    }
+
+    @Test
+    public void testGetOperationPathParam() {
+        Assert.assertEquals(Operation.UPDATE.getPathParam(), request.getOperationPathParam());
+    }
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/request/data/TestDataUpdateRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/data/TestDataUpdateRequest.java
@@ -5,7 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
-import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.Operation;
+import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.DataOperation;
 
 public class TestDataUpdateRequest extends AbstractLightblueRequestTest {
 
@@ -18,7 +18,7 @@ public class TestDataUpdateRequest extends AbstractLightblueRequestTest {
 
     @Test
     public void testGetOperationPathParam() {
-        Assert.assertEquals(Operation.UPDATE.getPathParam(), request.getOperationPathParam());
+        Assert.assertEquals(DataOperation.UPDATE.getPathParam(), request.getOperationPathParam());
     }
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataClearDefaultVersionsRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataClearDefaultVersionsRequest.java
@@ -4,20 +4,21 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest.MetadataOperation;
 import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 
 public class TestMetadataClearDefaultVersionsRequest extends AbstractLightblueRequestTest {
 
-	MetadataClearDefaultVersionRequest request = new MetadataClearDefaultVersionRequest();
+    MetadataClearDefaultVersionRequest request = new MetadataClearDefaultVersionRequest();
 
-	@Before
-	public void setUp() throws Exception {
-		request = new MetadataClearDefaultVersionRequest(entityName, entityVersion);
-	}
+    @Before
+    public void setUp() throws Exception {
+        request = new MetadataClearDefaultVersionRequest(entityName, entityVersion);
+    }
 
-	@Test
-	public void testGetOperationPathParam() {
-		Assert.assertEquals(MetadataGetEntityDependenciesRequest.PATH_PARAM_CLEAR_DEFAULT_VERSION, request.getOperationPathParam());
-	}
+    @Test
+    public void testGetOperationPathParam() {
+        Assert.assertEquals(MetadataOperation.CLEAR_DEFAULT_VERSION.getPathParam(), request.getOperationPathParam());
+    }
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataCreateRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataCreateRequest.java
@@ -4,20 +4,21 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest.MetadataOperation;
 import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 
 public class TestMetadataCreateRequest extends AbstractLightblueRequestTest {
 
-	MetadataCreateRequest request = new MetadataCreateRequest();
+    MetadataCreateRequest request = new MetadataCreateRequest();
 
-	@Before
-	public void setUp() throws Exception {
-		request = new MetadataCreateRequest(entityName, entityVersion);
-	}
+    @Before
+    public void setUp() throws Exception {
+        request = new MetadataCreateRequest(entityName, entityVersion);
+    }
 
-	@Test
-	public void testGetOperationPathParam() {
-		Assert.assertEquals(MetadataCreateRequest.PATH_PARAM_CREATE_METADATA, request.getOperationPathParam());
-	}
+    @Test
+    public void testGetOperationPathParam() {
+        Assert.assertEquals(MetadataOperation.CREATE_METADATA.getPathParam(), request.getOperationPathParam());
+    }
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataCreateSchemaRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataCreateSchemaRequest.java
@@ -4,20 +4,21 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest.MetadataOperation;
 import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 
 public class TestMetadataCreateSchemaRequest extends AbstractLightblueRequestTest {
 
-	MetadataCreateSchemaRequest request  = new MetadataCreateSchemaRequest();
+    MetadataCreateSchemaRequest request = new MetadataCreateSchemaRequest();
 
-	@Before
-	public void setUp() throws Exception {
-		request = new MetadataCreateSchemaRequest(entityName, entityVersion);
-	}
-	
-	@Test
-	public void testGetOperationPathParam() {
-		Assert.assertEquals(MetadataCreateSchemaRequest.PATH_PARAM_CREATE_METADATA, request.getOperationPathParam());
-	}
+    @Before
+    public void setUp() throws Exception {
+        request = new MetadataCreateSchemaRequest(entityName, entityVersion);
+    }
+
+    @Test
+    public void testGetOperationPathParam() {
+        Assert.assertEquals(MetadataOperation.CREATE_SCHEMA.getPathParam(), request.getOperationPathParam());
+    }
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataGetEntityDependenciesRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataGetEntityDependenciesRequest.java
@@ -4,20 +4,21 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest.MetadataOperation;
 import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 
 public class TestMetadataGetEntityDependenciesRequest extends AbstractLightblueRequestTest {
 
-	MetadataGetEntityDependenciesRequest request = new MetadataGetEntityDependenciesRequest();
+    MetadataGetEntityDependenciesRequest request = new MetadataGetEntityDependenciesRequest();
 
-	@Before
-	public void setUp() throws Exception {
-		request = new MetadataGetEntityDependenciesRequest(entityName, entityVersion);
-	}
+    @Before
+    public void setUp() throws Exception {
+        request = new MetadataGetEntityDependenciesRequest(entityName, entityVersion);
+    }
 
-	@Test
-	public void testGetOperationPathParam() {
-		Assert.assertEquals(MetadataGetEntityDependenciesRequest.PATH_PARAM_GET_ENTITY_DEPENDENCIES, request.getOperationPathParam());
-	}
+    @Test
+    public void testGetOperationPathParam() {
+        Assert.assertEquals(MetadataOperation.GET_ENTITY_DEPENDENCIES.getPathParam(), request.getOperationPathParam());
+    }
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataGetEntityMetadataRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataGetEntityMetadataRequest.java
@@ -4,20 +4,21 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest.MetadataOperation;
 import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 
-public class TestMetadataGetEntityMetadataRequest extends AbstractLightblueRequestTest  {
+public class TestMetadataGetEntityMetadataRequest extends AbstractLightblueRequestTest {
 
-	MetadataGetEntityMetadataRequest request = new MetadataGetEntityMetadataRequest();
-	
-	@Before
-	public void setUp() throws Exception {
-		request = new MetadataGetEntityMetadataRequest(entityName, entityVersion);
-	}
+    MetadataGetEntityMetadataRequest request = new MetadataGetEntityMetadataRequest();
 
-	@Test
-	public void testGetOperationPathParam() {
-		Assert.assertEquals(MetadataGetEntityMetadataRequest.PATH_PARAM_GET_ENTITY_METADATA, request.getOperationPathParam());
-	}
+    @Before
+    public void setUp() throws Exception {
+        request = new MetadataGetEntityMetadataRequest(entityName, entityVersion);
+    }
+
+    @Test
+    public void testGetOperationPathParam() {
+        Assert.assertEquals(MetadataOperation.GET_ENTITY_METADATA.getPathParam(), request.getOperationPathParam());
+    }
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataGetEntityNamesRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataGetEntityNamesRequest.java
@@ -4,20 +4,21 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest.MetadataOperation;
 import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 
 public class TestMetadataGetEntityNamesRequest extends AbstractLightblueRequestTest {
 
-	MetadataGetEntityNamesRequest request = new MetadataGetEntityNamesRequest();
+    MetadataGetEntityNamesRequest request = new MetadataGetEntityNamesRequest();
 
-	@Before
-	public void setUp() throws Exception {
-		request = new MetadataGetEntityNamesRequest(entityName, entityVersion);
-	}
+    @Before
+    public void setUp() throws Exception {
+        request = new MetadataGetEntityNamesRequest(entityName, entityVersion);
+    }
 
-	@Test
-	public void testGetOperationPathParam() {
-		Assert.assertEquals(MetadataGetEntityNamesRequest.PATH_PARAM_GET_ENTITY_NAMES, request.getOperationPathParam());
-	}
+    @Test
+    public void testGetOperationPathParam() {
+        Assert.assertEquals(MetadataOperation.GET_ENTITY_NAMES.getPathParam(), request.getOperationPathParam());
+    }
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataGetEntityRolesRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataGetEntityRolesRequest.java
@@ -4,20 +4,21 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest.MetadataOperation;
 import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 
 public class TestMetadataGetEntityRolesRequest extends AbstractLightblueRequestTest {
 
-	MetadataGetEntityRolesRequest request = new MetadataGetEntityRolesRequest();
+    MetadataGetEntityRolesRequest request = new MetadataGetEntityRolesRequest();
 
-	@Before
-	public void setUp() throws Exception {
-		request = new MetadataGetEntityRolesRequest(entityName, entityVersion);
-	}
+    @Before
+    public void setUp() throws Exception {
+        request = new MetadataGetEntityRolesRequest(entityName, entityVersion);
+    }
 
-	@Test
-	public void testGetOperationPathParam() {
-		Assert.assertEquals(MetadataGetEntityRolesRequest.PATH_PARAM_GET_ENTITY_ROLES, request.getOperationPathParam());
-	}
+    @Test
+    public void testGetOperationPathParam() {
+        Assert.assertEquals(MetadataOperation.GET_ENTITY_ROLES.getPathParam(), request.getOperationPathParam());
+    }
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataGetEntityVersionsRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataGetEntityVersionsRequest.java
@@ -4,20 +4,21 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest.MetadataOperation;
 import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 
 public class TestMetadataGetEntityVersionsRequest extends AbstractLightblueRequestTest {
 
-	MetadataGetEntityVersionsRequest request = new MetadataGetEntityVersionsRequest();
+    MetadataGetEntityVersionsRequest request = new MetadataGetEntityVersionsRequest();
 
-	@Before
-	public void setUp() throws Exception {
-		request = new MetadataGetEntityVersionsRequest(entityName, entityVersion);
-	}
+    @Before
+    public void setUp() throws Exception {
+        request = new MetadataGetEntityVersionsRequest(entityName, entityVersion);
+    }
 
-	@Test
-	public void testGetOperationPathParam() {
-		Assert.assertEquals(MetadataGetEntityRolesRequest.PATH_PARAM_GET_ENTITY_VERSIONS, request.getOperationPathParam());
-	}
+    @Test
+    public void testGetOperationPathParam() {
+        Assert.assertEquals(MetadataOperation.GET_ENTITY_VERSIONS.getPathParam(), request.getOperationPathParam());
+    }
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataRemoveEntityRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataRemoveEntityRequest.java
@@ -4,20 +4,21 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest.MetadataOperation;
 import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 
 public class TestMetadataRemoveEntityRequest extends AbstractLightblueRequestTest {
 
-	MetadataRemoveEntityRequest request = new MetadataRemoveEntityRequest();
+    MetadataRemoveEntityRequest request = new MetadataRemoveEntityRequest();
 
-	@Before
-	public void setUp() throws Exception {
-		request = new MetadataRemoveEntityRequest(entityName, entityVersion);
-	}
+    @Before
+    public void setUp() throws Exception {
+        request = new MetadataRemoveEntityRequest(entityName, entityVersion);
+    }
 
-	@Test
-	public void testGetOperationPathParam() {
-		Assert.assertEquals(MetadataGetEntityDependenciesRequest.PATH_PARAM_REMOVE_ENTITY, request.getOperationPathParam());
-	}
+    @Test
+    public void testGetOperationPathParam() {
+        Assert.assertEquals(MetadataOperation.REMOVE_ENTITY.getPathParam(), request.getOperationPathParam());
+    }
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataSetDefaultVersionRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataSetDefaultVersionRequest.java
@@ -4,20 +4,21 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest.MetadataOperation;
 import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 
 public class TestMetadataSetDefaultVersionRequest extends AbstractLightblueRequestTest {
 
-	MetadataSetDefaultVersionRequest request = new MetadataSetDefaultVersionRequest();
+    MetadataSetDefaultVersionRequest request = new MetadataSetDefaultVersionRequest();
 
-	@Before
-	public void setUp() throws Exception {
-		request = new MetadataSetDefaultVersionRequest(entityName, entityVersion);
-	}
+    @Before
+    public void setUp() throws Exception {
+        request = new MetadataSetDefaultVersionRequest(entityName, entityVersion);
+    }
 
-	@Test
-	public void testGetOperationPathParam() {
-		Assert.assertEquals(MetadataSetDefaultVersionRequest.PATH_PARAM_SET_DEFAULT_VERSION, request.getOperationPathParam());
-	}
+    @Test
+    public void testGetOperationPathParam() {
+        Assert.assertEquals(MetadataOperation.SET_DEFAULT_VERSION.getPathParam(), request.getOperationPathParam());
+    }
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataUpdateEntityInfoRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataUpdateEntityInfoRequest.java
@@ -4,20 +4,21 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest.MetadataOperation;
 import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 
 public class TestMetadataUpdateEntityInfoRequest extends AbstractLightblueRequestTest {
 
-	MetadataUpdateEntityInfoRequest request = new MetadataUpdateEntityInfoRequest();
+    MetadataUpdateEntityInfoRequest request = new MetadataUpdateEntityInfoRequest();
 
-	@Before
-	public void setUp() throws Exception {
-		request = new MetadataUpdateEntityInfoRequest(entityName, entityVersion);
-	}
+    @Before
+    public void setUp() throws Exception {
+        request = new MetadataUpdateEntityInfoRequest(entityName, entityVersion);
+    }
 
-	@Test
-	public void testGetOperationPathParam() {
-		Assert.assertEquals(MetadataUpdateEntityInfoRequest.PATH_PARAM_UPDATE_ENTITY_INFO, request.getOperationPathParam());
-	}
+    @Test
+    public void testGetOperationPathParam() {
+        Assert.assertEquals(MetadataOperation.UPDATE_ENTITY_INFO.getPathParam(), request.getOperationPathParam());
+    }
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataUpdateSchemaStatusRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/metadata/TestMetadataUpdateSchemaStatusRequest.java
@@ -4,20 +4,21 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest.MetadataOperation;
 import com.redhat.lightblue.client.request.AbstractLightblueRequestTest;
 
 public class TestMetadataUpdateSchemaStatusRequest extends AbstractLightblueRequestTest {
 
-	MetadataUpdateSchemaStatusRequest request = new MetadataUpdateSchemaStatusRequest();
+    MetadataUpdateSchemaStatusRequest request = new MetadataUpdateSchemaStatusRequest();
 
-	@Before
-	public void setUp() throws Exception {
-		request = new MetadataUpdateSchemaStatusRequest(entityName, entityVersion);
-	}
+    @Before
+    public void setUp() throws Exception {
+        request = new MetadataUpdateSchemaStatusRequest(entityName, entityVersion);
+    }
 
-	@Test
-	public void testGetOperationPathParam() {
-		Assert.assertEquals(MetadataUpdateSchemaStatusRequest.PATH_PARAM_UPDATE_SCHEMA_STATUS, request.getOperationPathParam());
-	}
+    @Test
+    public void testGetOperationPathParam() {
+        Assert.assertEquals(MetadataOperation.UPDATE_SCHEMA_STATUS.getPathParam(), request.getOperationPathParam());
+    }
 
 }

--- a/http/src/main/java/com/redhat/lightblue/client/http/request/LightblueHttpDataRequest.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/request/LightblueHttpDataRequest.java
@@ -2,37 +2,39 @@ package com.redhat.lightblue.client.http.request;
 
 import org.apache.http.client.methods.HttpRequestBase;
 
+import com.redhat.lightblue.client.request.AbstractLightblueDataRequest;
 import com.redhat.lightblue.client.request.LightblueRequest;
-import com.redhat.lightblue.client.request.data.DataDeleteRequest;
-import com.redhat.lightblue.client.request.data.DataFindRequest;
-import com.redhat.lightblue.client.request.data.DataInsertRequest;
-import com.redhat.lightblue.client.request.data.DataSaveRequest;
-import com.redhat.lightblue.client.request.data.DataUpdateRequest;
 
 public class LightblueHttpDataRequest extends AbstractLightblueHttpRequest implements LightblueHttpRequest {
 
-	LightblueRequest request;
-	
-	public LightblueHttpDataRequest(LightblueRequest request) {
-		this.request = request;
-	}
-	
-	@Override
-	public HttpRequestBase getRestRequest(String baseServiceURI) {
-		HttpRequestBase httpRequest = null;
+    private final LightblueRequest request;
 
-		if (request instanceof DataDeleteRequest) {
-			return getHttpPost(request.getRestURI(baseServiceURI), request.getBody());
-		} else if (request instanceof DataFindRequest) {
-			return getHttpPost(request.getRestURI(baseServiceURI), request.getBody());
-		} else if (request instanceof DataInsertRequest) {
-			return getHttpPut(request.getRestURI(baseServiceURI), request.getBody());
-		} else if (request instanceof DataSaveRequest) {
-			return getHttpPost(request.getRestURI(baseServiceURI), request.getBody());
-		} else if (request instanceof DataUpdateRequest) {
-			return getHttpPost(request.getRestURI(baseServiceURI), request.getBody());
-		}
-		return httpRequest;
-	}
+    public LightblueHttpDataRequest(LightblueRequest request) {
+        this.request = request;
+    }
+
+    @Override
+    public HttpRequestBase getRestRequest(String baseServiceURI) {
+        if (request instanceof AbstractLightblueDataRequest) {
+            AbstractLightblueDataRequest dataRequest = (AbstractLightblueDataRequest) request;
+            switch (dataRequest.getOperation()) {
+                case DELETE:
+                    return getHttpPost(dataRequest.getRestURI(baseServiceURI), dataRequest.getBody());
+                case FIND:
+                    return getHttpPost(dataRequest.getRestURI(baseServiceURI), dataRequest.getBody());
+                case INSERT:
+                    return getHttpPut(dataRequest.getRestURI(baseServiceURI), dataRequest.getBody());
+                case SAVE:
+                    return getHttpPost(dataRequest.getRestURI(baseServiceURI), dataRequest.getBody());
+                case UPDATE:
+                    return getHttpPost(dataRequest.getRestURI(baseServiceURI), dataRequest.getBody());
+                default:
+                    throw new UnsupportedOperationException("Unknown Operation type: " + request.getOperationPathParam());
+            }
+        }
+        else {
+            throw new UnsupportedOperationException("Request type is not supported: " + request.getClass());
+        }
+    }
 
 }

--- a/http/src/main/java/com/redhat/lightblue/client/http/request/LightblueHttpMetadataRequest.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/request/LightblueHttpMetadataRequest.java
@@ -2,58 +2,53 @@ package com.redhat.lightblue.client.http.request;
 
 import org.apache.http.client.methods.HttpRequestBase;
 
+import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest;
 import com.redhat.lightblue.client.request.LightblueRequest;
-import com.redhat.lightblue.client.request.metadata.MetadataClearDefaultVersionRequest;
-import com.redhat.lightblue.client.request.metadata.MetadataCreateRequest;
-import com.redhat.lightblue.client.request.metadata.MetadataCreateSchemaRequest;
-import com.redhat.lightblue.client.request.metadata.MetadataGetEntityDependenciesRequest;
-import com.redhat.lightblue.client.request.metadata.MetadataGetEntityMetadataRequest;
-import com.redhat.lightblue.client.request.metadata.MetadataGetEntityNamesRequest;
-import com.redhat.lightblue.client.request.metadata.MetadataGetEntityRolesRequest;
-import com.redhat.lightblue.client.request.metadata.MetadataGetEntityVersionsRequest;
-import com.redhat.lightblue.client.request.metadata.MetadataRemoveEntityRequest;
-import com.redhat.lightblue.client.request.metadata.MetadataSetDefaultVersionRequest;
-import com.redhat.lightblue.client.request.metadata.MetadataUpdateEntityInfoRequest;
-import com.redhat.lightblue.client.request.metadata.MetadataUpdateSchemaStatusRequest;
 
 public class LightblueHttpMetadataRequest extends AbstractLightblueHttpRequest implements LightblueHttpRequest {
 
-	LightblueRequest request;
+    LightblueRequest request;
 
-	public LightblueHttpMetadataRequest(LightblueRequest request) {
-		this.request = request;
-	}
+    public LightblueHttpMetadataRequest(LightblueRequest request) {
+        this.request = request;
+    }
 
-	@Override
-	public HttpRequestBase getRestRequest(String baseServiceURI) {
-		HttpRequestBase httpRequest = null;
-
-		if (request instanceof MetadataClearDefaultVersionRequest) {
-			return getHttpDelete(request.getRestURI(baseServiceURI));
-		} else if (request instanceof MetadataCreateRequest) {
-			return getHttpPut(request.getRestURI(baseServiceURI), request.getBody());
-		} else if (request instanceof MetadataCreateSchemaRequest) {
-			return getHttpPut(request.getRestURI(baseServiceURI), request.getBody());
-		} else if (request instanceof MetadataGetEntityDependenciesRequest) {
-			return getHttpGet(request.getRestURI(baseServiceURI));
-		} else if (request instanceof MetadataGetEntityMetadataRequest) {
-			return getHttpGet(request.getRestURI(baseServiceURI));
-		} else if (request instanceof MetadataGetEntityNamesRequest) {
-			return getHttpGet(request.getRestURI(baseServiceURI));
-		} else if (request instanceof MetadataGetEntityRolesRequest) {
-			return getHttpGet(request.getRestURI(baseServiceURI));
-		} else if (request instanceof MetadataGetEntityVersionsRequest) {
-			return getHttpGet(request.getRestURI(baseServiceURI));
-		} else if (request instanceof MetadataRemoveEntityRequest) {
-			return getHttpDelete(request.getRestURI(baseServiceURI));
-		} else if (request instanceof MetadataSetDefaultVersionRequest) {
-			return getHttpPost(request.getRestURI(baseServiceURI), request.getBody());
-		} else if (request instanceof MetadataUpdateEntityInfoRequest) {
-			return getHttpPut(request.getRestURI(baseServiceURI), request.getBody());
-		} else if (request instanceof MetadataUpdateSchemaStatusRequest) {
-			return getHttpPut(request.getRestURI(baseServiceURI), request.getBody());
-		}
-		return httpRequest;
-	}
+    @Override
+    public HttpRequestBase getRestRequest(String baseServiceURI) {
+        if (request instanceof AbstractLightblueMetadataRequest) {
+            AbstractLightblueMetadataRequest metadataRequest = (AbstractLightblueMetadataRequest) request;
+            switch (metadataRequest.getOperation()) {
+                case CLEAR_DEFAULT_VERSION:
+                    return getHttpDelete(request.getRestURI(baseServiceURI));
+                case CREATE_METADATA:
+                    return getHttpPut(request.getRestURI(baseServiceURI), request.getBody());
+                case CREATE_SCHEMA:
+                    return getHttpPut(request.getRestURI(baseServiceURI), request.getBody());
+                case GET_ENTITY_DEPENDENCIES:
+                    return getHttpGet(request.getRestURI(baseServiceURI));
+                case GET_ENTITY_METADATA:
+                    return getHttpGet(request.getRestURI(baseServiceURI));
+                case GET_ENTITY_NAMES:
+                    return getHttpGet(request.getRestURI(baseServiceURI));
+                case GET_ENTITY_ROLES:
+                    return getHttpGet(request.getRestURI(baseServiceURI));
+                case GET_ENTITY_VERSIONS:
+                    return getHttpGet(request.getRestURI(baseServiceURI));
+                case REMOVE_ENTITY:
+                    return getHttpDelete(request.getRestURI(baseServiceURI));
+                case SET_DEFAULT_VERSION:
+                    return getHttpPost(request.getRestURI(baseServiceURI), request.getBody());
+                case UPDATE_ENTITY_INFO:
+                    return getHttpPut(request.getRestURI(baseServiceURI), request.getBody());
+                case UPDATE_SCHEMA_STATUS:
+                    return getHttpPut(request.getRestURI(baseServiceURI), request.getBody());
+                default:
+                    throw new UnsupportedOperationException("Unknown Operation type: " + request.getOperationPathParam());
+            }
+        }
+        else {
+            throw new UnsupportedOperationException("Request type is not supported: " + request.getClass());
+        }
+    }
 
 }

--- a/http/src/test/java/com/redhat/lightblue/client/http/request/TestLightblueHttpDataRequest.java
+++ b/http/src/test/java/com/redhat/lightblue/client/http/request/TestLightblueHttpDataRequest.java
@@ -5,7 +5,6 @@ import static com.redhat.lightblue.client.expression.query.ValueQuery.withValue;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
-import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.StringEntity;
@@ -16,6 +15,7 @@ import com.redhat.lightblue.client.http.request.stub.DataFindRequestStub;
 import com.redhat.lightblue.client.http.request.stub.DataInsertRequestStub;
 import com.redhat.lightblue.client.http.request.stub.DataSaveRequestStub;
 import com.redhat.lightblue.client.http.request.stub.DataUpdateRequestStub;
+import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.Operation;
 import com.redhat.lightblue.client.request.data.DataDeleteRequest;
 import com.redhat.lightblue.client.request.data.DataFindRequest;
 import com.redhat.lightblue.client.request.data.DataInsertRequest;
@@ -24,165 +24,164 @@ import com.redhat.lightblue.client.request.data.DataUpdateRequest;
 
 public class TestLightblueHttpDataRequest extends AbstractLightblueHttpRequestTest {
 
-	LightblueHttpDataRequest httpRequest;
-	
-	@Before
-	public void setUp() throws Exception {
-		
-	}
-	
-	@Test
-	public void testGetRestRequestWithDataDeleteRequest() throws IOException {
-		DataDeleteRequest deleteRequest = new DataDeleteRequest();
-		deleteRequest.where(withValue("_id = 1234abc"));
-		httpRequest = new LightblueHttpDataRequest(deleteRequest);
-		HttpPost expectedRequest = new HttpPost(baseURI + DataDeleteRequest.PATH_PARAM_DELETE);
-		expectedRequest.setEntity(new StringEntity("{\"query\":{\"field\":\"_id\",\"op\":\"=\",\"rvalue\":\"1234abc\"}}"));
-		HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
-		compareHttpPost(expectedRequest, actualRequest);
-	}
-	
-	@Test
-	public void testGetRestRequestWithDataDeleteRequestWithEntityName() throws IOException {
-		DataDeleteRequest deleteRequest = new DataDeleteRequest(entityName, null);
-		deleteRequest.where(withValue("_id = 1234abc"));
-		httpRequest = new LightblueHttpDataRequest(deleteRequest);
-		HttpPost expectedRequest = new HttpPost(baseURI + DataDeleteRequest.PATH_PARAM_DELETE + "/" + entityName);
-		expectedRequest.setEntity(new StringEntity("{\"query\":{\"field\":\"_id\",\"op\":\"=\",\"rvalue\":\"1234abc\"}}"));
-		HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
-		compareHttpPost(expectedRequest, actualRequest);
-	}
+    LightblueHttpDataRequest httpRequest;
 
-	@Test
-	public void testGetRestRequestWithDataDeleteRequestWithEntityNameAndVersion() throws IOException {
-		DataDeleteRequest deleteRequest = new DataDeleteRequest(entityName, entityVersion);
-		deleteRequest.where(withValue("_id = 1234abc"));
-		httpRequest = new LightblueHttpDataRequest(deleteRequest);
-		HttpPost expectedRequest = new HttpPost(baseURI + DataDeleteRequest.PATH_PARAM_DELETE + "/" + entityName + "/" + entityVersion);
-		expectedRequest.setEntity(new StringEntity("{\"query\":{\"field\":\"_id\",\"op\":\"=\",\"rvalue\":\"1234abc\"}}"));
-		HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
-		compareHttpPost(expectedRequest, actualRequest);
-	}
-	
+    @Before
+    public void setUp() throws Exception {
 
-	@Test
-	public void testGetRestRequestWithDataFindRequest() throws UnsupportedEncodingException {
-		HttpPost expectedRequest = new HttpPost(baseURI + DataFindRequest.PATH_PARAM_FIND);
-		expectedRequest.setEntity(new StringEntity(body));
-		DataFindRequest request = new DataFindRequestStub(null, null, body);
-		httpRequest = new LightblueHttpDataRequest(request);
-		HttpPost actualRequest = (HttpPost)httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
-	
-	@Test
-	public void testGetRestRequestWithDataFindRequestWithEntityName() throws UnsupportedEncodingException {
-		DataFindRequest request = new DataFindRequestStub(entityName, null, body);
-		httpRequest = new LightblueHttpDataRequest(request);
-		HttpPost expectedRequest = new HttpPost(baseURI + DataFindRequest.PATH_PARAM_FIND +"/" + entityName);
-		expectedRequest.setEntity(new StringEntity(body));
-		HttpPost actualRequest = (HttpPost)httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
-	
-	@Test
-	public void testGetRestRequestWithDataFindRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
-		DataFindRequest request = new DataFindRequestStub(entityName, entityVersion, body);
-		httpRequest = new LightblueHttpDataRequest(request);
-		HttpPost expectedRequest = new HttpPost(baseURI + DataFindRequest.PATH_PARAM_FIND +"/" + entityName + "/" + entityVersion);
-		expectedRequest.setEntity(new StringEntity(body));
-		HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
-	
-	@Test
-	public void testGetRestRequestWithDataInsertRequest() throws IOException {
-		DataInsertRequest request = new DataInsertRequestStub(null, null, body);
-		httpRequest = new LightblueHttpDataRequest(request);
-		HttpPut expectedRequest = new HttpPut(baseURI);
-		expectedRequest.setEntity(new StringEntity(body));
-		HttpPut actualRequest = (HttpPut)httpRequest.getRestRequest(baseURI);
-		compareHttpPut(expectedRequest, actualRequest);
-	}
-	
-	@Test
-	public void testGetRestRequestWithDataInsertRequestWithEntityName() throws IOException {
-		DataInsertRequest request = new DataInsertRequestStub(entityName, null, body);
-		httpRequest = new LightblueHttpDataRequest(request);
-		HttpPut expectedRequest = new HttpPut(baseURI + entityName );
-		expectedRequest.setEntity(new StringEntity(body));
-		HttpPut actualRequest = (HttpPut)httpRequest.getRestRequest(baseURI);
-		compareHttpPut(expectedRequest, actualRequest);	
-	}
-	
-	@Test
-	public void testGetRestRequestWithDataInsertRequestWithEntityNameAndVersion() throws IOException {
-		DataInsertRequest request = new DataInsertRequestStub(entityName, entityVersion, body);
-		httpRequest = new LightblueHttpDataRequest(request);
-		HttpPut expectedRequest = new HttpPut(baseURI + entityName + "/" + entityVersion);
-		expectedRequest.setEntity(new StringEntity(body));
-		HttpPut actualRequest = (HttpPut)httpRequest.getRestRequest(baseURI);
-		compareHttpPut(expectedRequest, actualRequest);
-	}
-	
-	@Test
-	public void testGetRestRequestWithDataSaveRequest() throws IOException {
-		DataSaveRequest request = new DataSaveRequestStub(null, null, body);
-		httpRequest = new LightblueHttpDataRequest(request);
-		HttpPost expectedRequest = new HttpPost(baseURI + DataSaveRequest.PATH_PARAM_SAVE);
-		expectedRequest.setEntity(new StringEntity(body));
-		HttpPost actualRequest = (HttpPost)httpRequest.getRestRequest(baseURI);
-		compareHttpPost(expectedRequest, actualRequest);
-	}
-	
-	@Test
-	public void testGetRestRequestWithDataSaveRequestWithEntityName() throws IOException {
-		DataSaveRequest request = new DataSaveRequestStub(entityName, null, body);
-		httpRequest = new LightblueHttpDataRequest(request);
-		HttpPost expectedRequest = new HttpPost(baseURI + DataSaveRequest.PATH_PARAM_SAVE + "/" + entityName);
-		expectedRequest.setEntity(new StringEntity(body));
-		HttpPost actualRequest = (HttpPost)httpRequest.getRestRequest(baseURI);
-		compareHttpPost(expectedRequest, actualRequest);
-	}
-	
-	@Test
-	public void testGetRestRequestWithDataSaveRequestWithEntityNameAndVersion() throws IOException {
-		DataSaveRequest request = new DataSaveRequestStub(entityName, entityVersion, body);
-		httpRequest = new LightblueHttpDataRequest(request);
-		HttpPost expectedRequest = new HttpPost(baseURI + DataSaveRequest.PATH_PARAM_SAVE + "/" + entityName + "/" + entityVersion);
-		expectedRequest.setEntity(new StringEntity(body));
-		HttpPost actualRequest = (HttpPost)httpRequest.getRestRequest(baseURI);
-		compareHttpPost(expectedRequest, actualRequest);
-	}
-	
-	@Test
-	public void testGetRestRequestWithDataUpdateRequest() throws IOException {
-		DataUpdateRequest request = new DataUpdateRequestStub(null, null, body);
-		httpRequest = new LightblueHttpDataRequest(request);
-		HttpPost expectedRequest = new HttpPost(baseURI + DataUpdateRequest.PATH_PARAM_UPDATE);
-		expectedRequest.setEntity(new StringEntity(body));
-		HttpPost actualRequest = (HttpPost)httpRequest.getRestRequest(baseURI);
-		compareHttpPost(expectedRequest, actualRequest);
-	}
-	
-	@Test
-	public void testGetRestRequestWithDataUpdateRequestWithEntityName() throws IOException {
-		DataUpdateRequest request = new DataUpdateRequestStub(entityName, null, body);
-		httpRequest = new LightblueHttpDataRequest(request);
-		HttpPost expectedRequest = new HttpPost(baseURI + DataUpdateRequest.PATH_PARAM_UPDATE + "/" + entityName);
-		expectedRequest.setEntity(new StringEntity(body));
-		HttpPost actualRequest = (HttpPost)httpRequest.getRestRequest(baseURI);
-		compareHttpPost(expectedRequest, actualRequest);
-	}
-	
-	@Test
-	public void testGetRestRequestWithDataUpdateRequestWithEntityNameAndVersion() throws IOException {
-		DataUpdateRequest request = new DataUpdateRequestStub(entityName, entityVersion, body);
-		httpRequest = new LightblueHttpDataRequest(request);
-		HttpPost expectedRequest = new HttpPost(baseURI + DataUpdateRequest.PATH_PARAM_UPDATE + "/" + entityName + "/" + entityVersion);
-		expectedRequest.setEntity(new StringEntity(body));
-		HttpPost actualRequest = (HttpPost)httpRequest.getRestRequest(baseURI);
-		compareHttpPost(expectedRequest, actualRequest);
-	}
-	
+    }
+
+    @Test
+    public void testGetRestRequestWithDataDeleteRequest() throws IOException {
+        DataDeleteRequest deleteRequest = new DataDeleteRequest();
+        deleteRequest.where(withValue("_id = 1234abc"));
+        httpRequest = new LightblueHttpDataRequest(deleteRequest);
+        HttpPost expectedRequest = new HttpPost(baseURI + Operation.DELETE.getPathParam());
+        expectedRequest.setEntity(new StringEntity("{\"query\":{\"field\":\"_id\",\"op\":\"=\",\"rvalue\":\"1234abc\"}}"));
+        HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
+        compareHttpPost(expectedRequest, actualRequest);
+    }
+
+    @Test
+    public void testGetRestRequestWithDataDeleteRequestWithEntityName() throws IOException {
+        DataDeleteRequest deleteRequest = new DataDeleteRequest(entityName, null);
+        deleteRequest.where(withValue("_id = 1234abc"));
+        httpRequest = new LightblueHttpDataRequest(deleteRequest);
+        HttpPost expectedRequest = new HttpPost(baseURI + Operation.DELETE.getPathParam() + "/" + entityName);
+        expectedRequest.setEntity(new StringEntity("{\"query\":{\"field\":\"_id\",\"op\":\"=\",\"rvalue\":\"1234abc\"}}"));
+        HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
+        compareHttpPost(expectedRequest, actualRequest);
+    }
+
+    @Test
+    public void testGetRestRequestWithDataDeleteRequestWithEntityNameAndVersion() throws IOException {
+        DataDeleteRequest deleteRequest = new DataDeleteRequest(entityName, entityVersion);
+        deleteRequest.where(withValue("_id = 1234abc"));
+        httpRequest = new LightblueHttpDataRequest(deleteRequest);
+        HttpPost expectedRequest = new HttpPost(baseURI + Operation.DELETE.getPathParam() + "/" + entityName + "/" + entityVersion);
+        expectedRequest.setEntity(new StringEntity("{\"query\":{\"field\":\"_id\",\"op\":\"=\",\"rvalue\":\"1234abc\"}}"));
+        HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
+        compareHttpPost(expectedRequest, actualRequest);
+    }
+
+    @Test
+    public void testGetRestRequestWithDataFindRequest() throws UnsupportedEncodingException {
+        HttpPost expectedRequest = new HttpPost(baseURI + Operation.FIND.getPathParam());
+        expectedRequest.setEntity(new StringEntity(body));
+        DataFindRequest request = new DataFindRequestStub(null, null, body);
+        httpRequest = new LightblueHttpDataRequest(request);
+        HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
+
+    @Test
+    public void testGetRestRequestWithDataFindRequestWithEntityName() throws UnsupportedEncodingException {
+        DataFindRequest request = new DataFindRequestStub(entityName, null, body);
+        httpRequest = new LightblueHttpDataRequest(request);
+        HttpPost expectedRequest = new HttpPost(baseURI + Operation.FIND.getPathParam() + "/" + entityName);
+        expectedRequest.setEntity(new StringEntity(body));
+        HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
+
+    @Test
+    public void testGetRestRequestWithDataFindRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
+        DataFindRequest request = new DataFindRequestStub(entityName, entityVersion, body);
+        httpRequest = new LightblueHttpDataRequest(request);
+        HttpPost expectedRequest = new HttpPost(baseURI + Operation.FIND.getPathParam() + "/" + entityName + "/" + entityVersion);
+        expectedRequest.setEntity(new StringEntity(body));
+        HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
+
+    @Test
+    public void testGetRestRequestWithDataInsertRequest() throws IOException {
+        DataInsertRequest request = new DataInsertRequestStub(null, null, body);
+        httpRequest = new LightblueHttpDataRequest(request);
+        HttpPut expectedRequest = new HttpPut(baseURI);
+        expectedRequest.setEntity(new StringEntity(body));
+        HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
+        compareHttpPut(expectedRequest, actualRequest);
+    }
+
+    @Test
+    public void testGetRestRequestWithDataInsertRequestWithEntityName() throws IOException {
+        DataInsertRequest request = new DataInsertRequestStub(entityName, null, body);
+        httpRequest = new LightblueHttpDataRequest(request);
+        HttpPut expectedRequest = new HttpPut(baseURI + entityName);
+        expectedRequest.setEntity(new StringEntity(body));
+        HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
+        compareHttpPut(expectedRequest, actualRequest);
+    }
+
+    @Test
+    public void testGetRestRequestWithDataInsertRequestWithEntityNameAndVersion() throws IOException {
+        DataInsertRequest request = new DataInsertRequestStub(entityName, entityVersion, body);
+        httpRequest = new LightblueHttpDataRequest(request);
+        HttpPut expectedRequest = new HttpPut(baseURI + entityName + "/" + entityVersion);
+        expectedRequest.setEntity(new StringEntity(body));
+        HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
+        compareHttpPut(expectedRequest, actualRequest);
+    }
+
+    @Test
+    public void testGetRestRequestWithDataSaveRequest() throws IOException {
+        DataSaveRequest request = new DataSaveRequestStub(null, null, body);
+        httpRequest = new LightblueHttpDataRequest(request);
+        HttpPost expectedRequest = new HttpPost(baseURI + Operation.SAVE.getPathParam());
+        expectedRequest.setEntity(new StringEntity(body));
+        HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
+        compareHttpPost(expectedRequest, actualRequest);
+    }
+
+    @Test
+    public void testGetRestRequestWithDataSaveRequestWithEntityName() throws IOException {
+        DataSaveRequest request = new DataSaveRequestStub(entityName, null, body);
+        httpRequest = new LightblueHttpDataRequest(request);
+        HttpPost expectedRequest = new HttpPost(baseURI + Operation.SAVE.getPathParam() + "/" + entityName);
+        expectedRequest.setEntity(new StringEntity(body));
+        HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
+        compareHttpPost(expectedRequest, actualRequest);
+    }
+
+    @Test
+    public void testGetRestRequestWithDataSaveRequestWithEntityNameAndVersion() throws IOException {
+        DataSaveRequest request = new DataSaveRequestStub(entityName, entityVersion, body);
+        httpRequest = new LightblueHttpDataRequest(request);
+        HttpPost expectedRequest = new HttpPost(baseURI + Operation.SAVE.getPathParam() + "/" + entityName + "/" + entityVersion);
+        expectedRequest.setEntity(new StringEntity(body));
+        HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
+        compareHttpPost(expectedRequest, actualRequest);
+    }
+
+    @Test
+    public void testGetRestRequestWithDataUpdateRequest() throws IOException {
+        DataUpdateRequest request = new DataUpdateRequestStub(null, null, body);
+        httpRequest = new LightblueHttpDataRequest(request);
+        HttpPost expectedRequest = new HttpPost(baseURI + Operation.UPDATE.getPathParam());
+        expectedRequest.setEntity(new StringEntity(body));
+        HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
+        compareHttpPost(expectedRequest, actualRequest);
+    }
+
+    @Test
+    public void testGetRestRequestWithDataUpdateRequestWithEntityName() throws IOException {
+        DataUpdateRequest request = new DataUpdateRequestStub(entityName, null, body);
+        httpRequest = new LightblueHttpDataRequest(request);
+        HttpPost expectedRequest = new HttpPost(baseURI + Operation.UPDATE.getPathParam() + "/" + entityName);
+        expectedRequest.setEntity(new StringEntity(body));
+        HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
+        compareHttpPost(expectedRequest, actualRequest);
+    }
+
+    @Test
+    public void testGetRestRequestWithDataUpdateRequestWithEntityNameAndVersion() throws IOException {
+        DataUpdateRequest request = new DataUpdateRequestStub(entityName, entityVersion, body);
+        httpRequest = new LightblueHttpDataRequest(request);
+        HttpPost expectedRequest = new HttpPost(baseURI + Operation.UPDATE.getPathParam() + "/" + entityName + "/" + entityVersion);
+        expectedRequest.setEntity(new StringEntity(body));
+        HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
+        compareHttpPost(expectedRequest, actualRequest);
+    }
+
 }

--- a/http/src/test/java/com/redhat/lightblue/client/http/request/TestLightblueHttpDataRequest.java
+++ b/http/src/test/java/com/redhat/lightblue/client/http/request/TestLightblueHttpDataRequest.java
@@ -15,7 +15,7 @@ import com.redhat.lightblue.client.http.request.stub.DataFindRequestStub;
 import com.redhat.lightblue.client.http.request.stub.DataInsertRequestStub;
 import com.redhat.lightblue.client.http.request.stub.DataSaveRequestStub;
 import com.redhat.lightblue.client.http.request.stub.DataUpdateRequestStub;
-import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.Operation;
+import com.redhat.lightblue.client.request.AbstractLightblueDataRequest.DataOperation;
 import com.redhat.lightblue.client.request.data.DataDeleteRequest;
 import com.redhat.lightblue.client.request.data.DataFindRequest;
 import com.redhat.lightblue.client.request.data.DataInsertRequest;
@@ -36,7 +36,7 @@ public class TestLightblueHttpDataRequest extends AbstractLightblueHttpRequestTe
         DataDeleteRequest deleteRequest = new DataDeleteRequest();
         deleteRequest.where(withValue("_id = 1234abc"));
         httpRequest = new LightblueHttpDataRequest(deleteRequest);
-        HttpPost expectedRequest = new HttpPost(baseURI + Operation.DELETE.getPathParam());
+        HttpPost expectedRequest = new HttpPost(baseURI + DataOperation.DELETE.getPathParam());
         expectedRequest.setEntity(new StringEntity("{\"query\":{\"field\":\"_id\",\"op\":\"=\",\"rvalue\":\"1234abc\"}}"));
         HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
         compareHttpPost(expectedRequest, actualRequest);
@@ -47,7 +47,7 @@ public class TestLightblueHttpDataRequest extends AbstractLightblueHttpRequestTe
         DataDeleteRequest deleteRequest = new DataDeleteRequest(entityName, null);
         deleteRequest.where(withValue("_id = 1234abc"));
         httpRequest = new LightblueHttpDataRequest(deleteRequest);
-        HttpPost expectedRequest = new HttpPost(baseURI + Operation.DELETE.getPathParam() + "/" + entityName);
+        HttpPost expectedRequest = new HttpPost(baseURI + DataOperation.DELETE.getPathParam() + "/" + entityName);
         expectedRequest.setEntity(new StringEntity("{\"query\":{\"field\":\"_id\",\"op\":\"=\",\"rvalue\":\"1234abc\"}}"));
         HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
         compareHttpPost(expectedRequest, actualRequest);
@@ -58,7 +58,7 @@ public class TestLightblueHttpDataRequest extends AbstractLightblueHttpRequestTe
         DataDeleteRequest deleteRequest = new DataDeleteRequest(entityName, entityVersion);
         deleteRequest.where(withValue("_id = 1234abc"));
         httpRequest = new LightblueHttpDataRequest(deleteRequest);
-        HttpPost expectedRequest = new HttpPost(baseURI + Operation.DELETE.getPathParam() + "/" + entityName + "/" + entityVersion);
+        HttpPost expectedRequest = new HttpPost(baseURI + DataOperation.DELETE.getPathParam() + "/" + entityName + "/" + entityVersion);
         expectedRequest.setEntity(new StringEntity("{\"query\":{\"field\":\"_id\",\"op\":\"=\",\"rvalue\":\"1234abc\"}}"));
         HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
         compareHttpPost(expectedRequest, actualRequest);
@@ -66,7 +66,7 @@ public class TestLightblueHttpDataRequest extends AbstractLightblueHttpRequestTe
 
     @Test
     public void testGetRestRequestWithDataFindRequest() throws UnsupportedEncodingException {
-        HttpPost expectedRequest = new HttpPost(baseURI + Operation.FIND.getPathParam());
+        HttpPost expectedRequest = new HttpPost(baseURI + DataOperation.FIND.getPathParam());
         expectedRequest.setEntity(new StringEntity(body));
         DataFindRequest request = new DataFindRequestStub(null, null, body);
         httpRequest = new LightblueHttpDataRequest(request);
@@ -78,7 +78,7 @@ public class TestLightblueHttpDataRequest extends AbstractLightblueHttpRequestTe
     public void testGetRestRequestWithDataFindRequestWithEntityName() throws UnsupportedEncodingException {
         DataFindRequest request = new DataFindRequestStub(entityName, null, body);
         httpRequest = new LightblueHttpDataRequest(request);
-        HttpPost expectedRequest = new HttpPost(baseURI + Operation.FIND.getPathParam() + "/" + entityName);
+        HttpPost expectedRequest = new HttpPost(baseURI + DataOperation.FIND.getPathParam() + "/" + entityName);
         expectedRequest.setEntity(new StringEntity(body));
         HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
         compareHttpRequestBase(expectedRequest, actualRequest);
@@ -88,7 +88,7 @@ public class TestLightblueHttpDataRequest extends AbstractLightblueHttpRequestTe
     public void testGetRestRequestWithDataFindRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
         DataFindRequest request = new DataFindRequestStub(entityName, entityVersion, body);
         httpRequest = new LightblueHttpDataRequest(request);
-        HttpPost expectedRequest = new HttpPost(baseURI + Operation.FIND.getPathParam() + "/" + entityName + "/" + entityVersion);
+        HttpPost expectedRequest = new HttpPost(baseURI + DataOperation.FIND.getPathParam() + "/" + entityName + "/" + entityVersion);
         expectedRequest.setEntity(new StringEntity(body));
         HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
         compareHttpRequestBase(expectedRequest, actualRequest);
@@ -128,7 +128,7 @@ public class TestLightblueHttpDataRequest extends AbstractLightblueHttpRequestTe
     public void testGetRestRequestWithDataSaveRequest() throws IOException {
         DataSaveRequest request = new DataSaveRequestStub(null, null, body);
         httpRequest = new LightblueHttpDataRequest(request);
-        HttpPost expectedRequest = new HttpPost(baseURI + Operation.SAVE.getPathParam());
+        HttpPost expectedRequest = new HttpPost(baseURI + DataOperation.SAVE.getPathParam());
         expectedRequest.setEntity(new StringEntity(body));
         HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
         compareHttpPost(expectedRequest, actualRequest);
@@ -138,7 +138,7 @@ public class TestLightblueHttpDataRequest extends AbstractLightblueHttpRequestTe
     public void testGetRestRequestWithDataSaveRequestWithEntityName() throws IOException {
         DataSaveRequest request = new DataSaveRequestStub(entityName, null, body);
         httpRequest = new LightblueHttpDataRequest(request);
-        HttpPost expectedRequest = new HttpPost(baseURI + Operation.SAVE.getPathParam() + "/" + entityName);
+        HttpPost expectedRequest = new HttpPost(baseURI + DataOperation.SAVE.getPathParam() + "/" + entityName);
         expectedRequest.setEntity(new StringEntity(body));
         HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
         compareHttpPost(expectedRequest, actualRequest);
@@ -148,7 +148,7 @@ public class TestLightblueHttpDataRequest extends AbstractLightblueHttpRequestTe
     public void testGetRestRequestWithDataSaveRequestWithEntityNameAndVersion() throws IOException {
         DataSaveRequest request = new DataSaveRequestStub(entityName, entityVersion, body);
         httpRequest = new LightblueHttpDataRequest(request);
-        HttpPost expectedRequest = new HttpPost(baseURI + Operation.SAVE.getPathParam() + "/" + entityName + "/" + entityVersion);
+        HttpPost expectedRequest = new HttpPost(baseURI + DataOperation.SAVE.getPathParam() + "/" + entityName + "/" + entityVersion);
         expectedRequest.setEntity(new StringEntity(body));
         HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
         compareHttpPost(expectedRequest, actualRequest);
@@ -158,7 +158,7 @@ public class TestLightblueHttpDataRequest extends AbstractLightblueHttpRequestTe
     public void testGetRestRequestWithDataUpdateRequest() throws IOException {
         DataUpdateRequest request = new DataUpdateRequestStub(null, null, body);
         httpRequest = new LightblueHttpDataRequest(request);
-        HttpPost expectedRequest = new HttpPost(baseURI + Operation.UPDATE.getPathParam());
+        HttpPost expectedRequest = new HttpPost(baseURI + DataOperation.UPDATE.getPathParam());
         expectedRequest.setEntity(new StringEntity(body));
         HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
         compareHttpPost(expectedRequest, actualRequest);
@@ -168,7 +168,7 @@ public class TestLightblueHttpDataRequest extends AbstractLightblueHttpRequestTe
     public void testGetRestRequestWithDataUpdateRequestWithEntityName() throws IOException {
         DataUpdateRequest request = new DataUpdateRequestStub(entityName, null, body);
         httpRequest = new LightblueHttpDataRequest(request);
-        HttpPost expectedRequest = new HttpPost(baseURI + Operation.UPDATE.getPathParam() + "/" + entityName);
+        HttpPost expectedRequest = new HttpPost(baseURI + DataOperation.UPDATE.getPathParam() + "/" + entityName);
         expectedRequest.setEntity(new StringEntity(body));
         HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
         compareHttpPost(expectedRequest, actualRequest);
@@ -178,7 +178,7 @@ public class TestLightblueHttpDataRequest extends AbstractLightblueHttpRequestTe
     public void testGetRestRequestWithDataUpdateRequestWithEntityNameAndVersion() throws IOException {
         DataUpdateRequest request = new DataUpdateRequestStub(entityName, entityVersion, body);
         httpRequest = new LightblueHttpDataRequest(request);
-        HttpPost expectedRequest = new HttpPost(baseURI + Operation.UPDATE.getPathParam() + "/" + entityName + "/" + entityVersion);
+        HttpPost expectedRequest = new HttpPost(baseURI + DataOperation.UPDATE.getPathParam() + "/" + entityName + "/" + entityVersion);
         expectedRequest.setEntity(new StringEntity(body));
         HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
         compareHttpPost(expectedRequest, actualRequest);

--- a/http/src/test/java/com/redhat/lightblue/client/http/request/TestLightblueHttpMetadataRequest.java
+++ b/http/src/test/java/com/redhat/lightblue/client/http/request/TestLightblueHttpMetadataRequest.java
@@ -9,6 +9,7 @@ import org.apache.http.client.methods.HttpPut;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest.MetadataOperation;
 import com.redhat.lightblue.client.request.metadata.MetadataClearDefaultVersionRequest;
 import com.redhat.lightblue.client.request.metadata.MetadataCreateRequest;
 import com.redhat.lightblue.client.request.metadata.MetadataCreateSchemaRequest;
@@ -24,351 +25,351 @@ import com.redhat.lightblue.client.request.metadata.MetadataUpdateSchemaStatusRe
 
 public class TestLightblueHttpMetadataRequest extends AbstractLightblueHttpRequestTest {
 
-	LightblueHttpMetadataRequest httpRequest;
+    LightblueHttpMetadataRequest httpRequest;
 
-	@Before
-	public void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
 
-	}
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataClearDefaultVersionRequest() {
-		MetadataClearDefaultVersionRequest request = new MetadataClearDefaultVersionRequest();
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpDelete expectedRequest = new HttpDelete(baseURI);
-		HttpDelete actualRequest = (HttpDelete) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataClearDefaultVersionRequest() {
+        MetadataClearDefaultVersionRequest request = new MetadataClearDefaultVersionRequest();
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpDelete expectedRequest = new HttpDelete(baseURI);
+        HttpDelete actualRequest = (HttpDelete) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataClearDefaultVersionRequestWithEntityName() {
-		MetadataClearDefaultVersionRequest request = new MetadataClearDefaultVersionRequest(entityName, null);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpDelete expectedRequest = new HttpDelete(baseURI + entityName);
-		HttpDelete actualRequest = (HttpDelete) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataClearDefaultVersionRequestWithEntityName() {
+        MetadataClearDefaultVersionRequest request = new MetadataClearDefaultVersionRequest(entityName, null);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpDelete expectedRequest = new HttpDelete(baseURI + entityName);
+        HttpDelete actualRequest = (HttpDelete) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataClearDefaultVersionRequestWithEntityNameAndVersion() {
-		MetadataClearDefaultVersionRequest request = new MetadataClearDefaultVersionRequest(entityName, entityVersion);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpDelete expectedRequest = new HttpDelete(baseURI + entityName + "/" + entityVersion);
-		HttpDelete actualRequest = (HttpDelete) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataClearDefaultVersionRequestWithEntityNameAndVersion() {
+        MetadataClearDefaultVersionRequest request = new MetadataClearDefaultVersionRequest(entityName, entityVersion);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpDelete expectedRequest = new HttpDelete(baseURI + entityName + "/" + entityVersion);
+        HttpDelete actualRequest = (HttpDelete) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataCreateRequest() throws UnsupportedEncodingException {
-		MetadataCreateRequest request = new MetadataCreateRequest();
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpPut expectedRequest = new HttpPut(baseURI);
-		request.setBody(body);
-		HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataCreateRequest() throws UnsupportedEncodingException {
+        MetadataCreateRequest request = new MetadataCreateRequest();
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpPut expectedRequest = new HttpPut(baseURI);
+        request.setBody(body);
+        HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataCreateRequestWithEntityName() throws UnsupportedEncodingException {
-		MetadataCreateRequest request = new MetadataCreateRequest(entityName, null);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpPut expectedRequest = new HttpPut(baseURI + entityName);
-		request.setBody(body);
-		HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataCreateRequestWithEntityName() throws UnsupportedEncodingException {
+        MetadataCreateRequest request = new MetadataCreateRequest(entityName, null);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpPut expectedRequest = new HttpPut(baseURI + entityName);
+        request.setBody(body);
+        HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataCreateRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
-		MetadataCreateRequest request = new MetadataCreateRequest(entityName, entityVersion);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpPut expectedRequest = new HttpPut(baseURI + entityName + "/" + entityVersion);
-		request.setBody(body);
-		HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataCreateRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
+        MetadataCreateRequest request = new MetadataCreateRequest(entityName, entityVersion);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpPut expectedRequest = new HttpPut(baseURI + entityName + "/" + entityVersion);
+        request.setBody(body);
+        HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataCreateSchemaRequest() throws UnsupportedEncodingException {
-		MetadataCreateSchemaRequest request = new MetadataCreateSchemaRequest();
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpPut expectedRequest = new HttpPut(baseURI);
-		request.setBody(body);
-		HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataCreateSchemaRequest() throws UnsupportedEncodingException {
+        MetadataCreateSchemaRequest request = new MetadataCreateSchemaRequest();
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpPut expectedRequest = new HttpPut(baseURI);
+        request.setBody(body);
+        HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataCreateSchemaRequestWithEntityName() throws UnsupportedEncodingException {
-		MetadataCreateSchemaRequest request = new MetadataCreateSchemaRequest(entityName, null);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpPut expectedRequest = new HttpPut(baseURI + entityName);
-		request.setBody(body);
-		HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataCreateSchemaRequestWithEntityName() throws UnsupportedEncodingException {
+        MetadataCreateSchemaRequest request = new MetadataCreateSchemaRequest(entityName, null);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpPut expectedRequest = new HttpPut(baseURI + entityName);
+        request.setBody(body);
+        HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataCreateSchemaRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
-		MetadataCreateSchemaRequest request = new MetadataCreateSchemaRequest(entityName, entityVersion);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpPut expectedRequest = new HttpPut(baseURI + entityName + "/" + entityVersion);
-		request.setBody(body);
-		HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataCreateSchemaRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
+        MetadataCreateSchemaRequest request = new MetadataCreateSchemaRequest(entityName, entityVersion);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpPut expectedRequest = new HttpPut(baseURI + entityName + "/" + entityVersion);
+        request.setBody(body);
+        HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataGetEntityDependenciesRequest() throws UnsupportedEncodingException {
-		MetadataGetEntityDependenciesRequest request = new MetadataGetEntityDependenciesRequest();
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpGet expectedRequest = new HttpGet(baseURI + MetadataGetEntityDependenciesRequest.PATH_PARAM_GET_ENTITY_DEPENDENCIES);
-		HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataGetEntityDependenciesRequest() throws UnsupportedEncodingException {
+        MetadataGetEntityDependenciesRequest request = new MetadataGetEntityDependenciesRequest();
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpGet expectedRequest = new HttpGet(baseURI + MetadataOperation.GET_ENTITY_DEPENDENCIES.getPathParam());
+        HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataGetEntityDependenciesRequestWithEntityName() throws UnsupportedEncodingException {
-		MetadataGetEntityDependenciesRequest request = new MetadataGetEntityDependenciesRequest(entityName, null);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpGet expectedRequest = new HttpGet(baseURI + entityName + "/" + MetadataGetEntityDependenciesRequest.PATH_PARAM_GET_ENTITY_DEPENDENCIES);
-		HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataGetEntityDependenciesRequestWithEntityName() throws UnsupportedEncodingException {
+        MetadataGetEntityDependenciesRequest request = new MetadataGetEntityDependenciesRequest(entityName, null);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpGet expectedRequest = new HttpGet(baseURI + entityName + "/" + MetadataOperation.GET_ENTITY_DEPENDENCIES.getPathParam());
+        HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataGetEntityDependenciesRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
-		MetadataGetEntityDependenciesRequest request = new MetadataGetEntityDependenciesRequest(entityName, entityVersion);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpGet expectedRequest = new HttpGet(baseURI + entityName + "/" + entityVersion + "/"
-		    + MetadataGetEntityDependenciesRequest.PATH_PARAM_GET_ENTITY_DEPENDENCIES);
-		HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataGetEntityDependenciesRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
+        MetadataGetEntityDependenciesRequest request = new MetadataGetEntityDependenciesRequest(entityName, entityVersion);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpGet expectedRequest = new HttpGet(baseURI + entityName + "/" + entityVersion + "/"
+                + MetadataOperation.GET_ENTITY_DEPENDENCIES.getPathParam());
+        HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataGetEntityMetadataRequest() throws UnsupportedEncodingException {
-		MetadataGetEntityMetadataRequest request = new MetadataGetEntityMetadataRequest();
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpGet expectedRequest = new HttpGet(baseURI);
-		HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataGetEntityMetadataRequest() throws UnsupportedEncodingException {
+        MetadataGetEntityMetadataRequest request = new MetadataGetEntityMetadataRequest();
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpGet expectedRequest = new HttpGet(baseURI);
+        HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataGetEntityMetadataRequestWithEntityName() throws UnsupportedEncodingException {
-		MetadataGetEntityMetadataRequest request = new MetadataGetEntityMetadataRequest(entityName, null);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpGet expectedRequest = new HttpGet(baseURI + entityName);
-		HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataGetEntityMetadataRequestWithEntityName() throws UnsupportedEncodingException {
+        MetadataGetEntityMetadataRequest request = new MetadataGetEntityMetadataRequest(entityName, null);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpGet expectedRequest = new HttpGet(baseURI + entityName);
+        HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataGetEntityMetadataRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
-		MetadataGetEntityMetadataRequest request = new MetadataGetEntityMetadataRequest(entityName, entityVersion);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpGet expectedRequest = new HttpGet(baseURI + entityName + "/" + entityVersion);
-		HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataGetEntityMetadataRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
+        MetadataGetEntityMetadataRequest request = new MetadataGetEntityMetadataRequest(entityName, entityVersion);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpGet expectedRequest = new HttpGet(baseURI + entityName + "/" + entityVersion);
+        HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataGetEntityNamesRequest() throws UnsupportedEncodingException {
-		MetadataGetEntityNamesRequest request = new MetadataGetEntityNamesRequest();
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpGet expectedRequest = new HttpGet(baseURI);
-		HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataGetEntityNamesRequest() throws UnsupportedEncodingException {
+        MetadataGetEntityNamesRequest request = new MetadataGetEntityNamesRequest();
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpGet expectedRequest = new HttpGet(baseURI);
+        HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataGetEntityNamesRequestWithEntityName() throws UnsupportedEncodingException {
-		MetadataGetEntityNamesRequest request = new MetadataGetEntityNamesRequest(entityName, null);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpGet expectedRequest = new HttpGet(baseURI + entityName);
-		HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataGetEntityNamesRequestWithEntityName() throws UnsupportedEncodingException {
+        MetadataGetEntityNamesRequest request = new MetadataGetEntityNamesRequest(entityName, null);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpGet expectedRequest = new HttpGet(baseURI + entityName);
+        HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataGetEntityNamesRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
-		MetadataGetEntityNamesRequest request = new MetadataGetEntityNamesRequest(entityName, entityVersion);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpGet expectedRequest = new HttpGet(baseURI + entityName + "/" + entityVersion);
-		HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataGetEntityNamesRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
+        MetadataGetEntityNamesRequest request = new MetadataGetEntityNamesRequest(entityName, entityVersion);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpGet expectedRequest = new HttpGet(baseURI + entityName + "/" + entityVersion);
+        HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataGetEntityRolesRequest() throws UnsupportedEncodingException {
-		MetadataGetEntityRolesRequest request = new MetadataGetEntityRolesRequest();
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpGet expectedRequest = new HttpGet(baseURI + MetadataGetEntityRolesRequest.PATH_PARAM_GET_ENTITY_ROLES);
-		HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataGetEntityRolesRequest() throws UnsupportedEncodingException {
+        MetadataGetEntityRolesRequest request = new MetadataGetEntityRolesRequest();
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpGet expectedRequest = new HttpGet(baseURI + MetadataOperation.GET_ENTITY_ROLES.getPathParam());
+        HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataGetEntityRolesRequestWithEntityName() throws UnsupportedEncodingException {
-		MetadataGetEntityRolesRequest request = new MetadataGetEntityRolesRequest(entityName, null);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpGet expectedRequest = new HttpGet(baseURI + entityName + "/" + MetadataGetEntityRolesRequest.PATH_PARAM_GET_ENTITY_ROLES);
-		HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataGetEntityRolesRequestWithEntityName() throws UnsupportedEncodingException {
+        MetadataGetEntityRolesRequest request = new MetadataGetEntityRolesRequest(entityName, null);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpGet expectedRequest = new HttpGet(baseURI + entityName + "/" + MetadataOperation.GET_ENTITY_ROLES.getPathParam());
+        HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataGetEntityRolesRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
-		MetadataGetEntityRolesRequest request = new MetadataGetEntityRolesRequest(entityName, entityVersion);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpGet expectedRequest = new HttpGet(baseURI + entityName + "/" + entityVersion + "/" + MetadataGetEntityRolesRequest.PATH_PARAM_GET_ENTITY_ROLES);
-		HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataGetEntityRolesRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
+        MetadataGetEntityRolesRequest request = new MetadataGetEntityRolesRequest(entityName, entityVersion);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpGet expectedRequest = new HttpGet(baseURI + entityName + "/" + entityVersion + "/" + MetadataOperation.GET_ENTITY_ROLES.getPathParam());
+        HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataGetEntityVersionsRequest() throws UnsupportedEncodingException {
-		MetadataGetEntityVersionsRequest request = new MetadataGetEntityVersionsRequest();
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpGet expectedRequest = new HttpGet(baseURI);
-		HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataGetEntityVersionsRequest() throws UnsupportedEncodingException {
+        MetadataGetEntityVersionsRequest request = new MetadataGetEntityVersionsRequest();
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpGet expectedRequest = new HttpGet(baseURI);
+        HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataGetEntityVersionsRequestWithEntityName() throws UnsupportedEncodingException {
-		MetadataGetEntityVersionsRequest request = new MetadataGetEntityVersionsRequest(entityName, null);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpGet expectedRequest = new HttpGet(baseURI + entityName);
-		HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataGetEntityVersionsRequestWithEntityName() throws UnsupportedEncodingException {
+        MetadataGetEntityVersionsRequest request = new MetadataGetEntityVersionsRequest(entityName, null);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpGet expectedRequest = new HttpGet(baseURI + entityName);
+        HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataGetEntityVersionsRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
-		MetadataGetEntityVersionsRequest request = new MetadataGetEntityVersionsRequest(entityName, entityVersion);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpGet expectedRequest = new HttpGet(baseURI + entityName + "/" + entityVersion);
-		HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataGetEntityVersionsRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
+        MetadataGetEntityVersionsRequest request = new MetadataGetEntityVersionsRequest(entityName, entityVersion);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpGet expectedRequest = new HttpGet(baseURI + entityName + "/" + entityVersion);
+        HttpGet actualRequest = (HttpGet) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataRemoveEntityRequest() throws UnsupportedEncodingException {
-		MetadataRemoveEntityRequest request = new MetadataRemoveEntityRequest();
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpDelete expectedRequest = new HttpDelete(baseURI);
-		HttpDelete actualRequest = (HttpDelete) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataRemoveEntityRequest() throws UnsupportedEncodingException {
+        MetadataRemoveEntityRequest request = new MetadataRemoveEntityRequest();
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpDelete expectedRequest = new HttpDelete(baseURI);
+        HttpDelete actualRequest = (HttpDelete) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataRemoveEntityRequestWithEntityName() throws UnsupportedEncodingException {
-		MetadataRemoveEntityRequest request = new MetadataRemoveEntityRequest(entityName, null);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpDelete expectedRequest = new HttpDelete(baseURI + entityName);
-		HttpDelete actualRequest = (HttpDelete) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataRemoveEntityRequestWithEntityName() throws UnsupportedEncodingException {
+        MetadataRemoveEntityRequest request = new MetadataRemoveEntityRequest(entityName, null);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpDelete expectedRequest = new HttpDelete(baseURI + entityName);
+        HttpDelete actualRequest = (HttpDelete) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataRemoveEntityRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
-		MetadataRemoveEntityRequest request = new MetadataRemoveEntityRequest(entityName, entityVersion);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpDelete expectedRequest = new HttpDelete(baseURI + entityName + "/" + entityVersion);
-		HttpDelete actualRequest = (HttpDelete) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataRemoveEntityRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
+        MetadataRemoveEntityRequest request = new MetadataRemoveEntityRequest(entityName, entityVersion);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpDelete expectedRequest = new HttpDelete(baseURI + entityName + "/" + entityVersion);
+        HttpDelete actualRequest = (HttpDelete) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataSetDefaultVersionRequest() throws UnsupportedEncodingException {
-		MetadataSetDefaultVersionRequest request = new MetadataSetDefaultVersionRequest();
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpPost expectedRequest = new HttpPost(baseURI + MetadataSetDefaultVersionRequest.PATH_PARAM_SET_DEFAULT_VERSION);
-		request.setBody(body);
-		HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataSetDefaultVersionRequest() throws UnsupportedEncodingException {
+        MetadataSetDefaultVersionRequest request = new MetadataSetDefaultVersionRequest();
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpPost expectedRequest = new HttpPost(baseURI + MetadataOperation.SET_DEFAULT_VERSION.getPathParam());
+        request.setBody(body);
+        HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataSetDefaultVersionRequestWithEntityName() throws UnsupportedEncodingException {
-		MetadataSetDefaultVersionRequest request = new MetadataSetDefaultVersionRequest(entityName, null);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpPost expectedRequest = new HttpPost(baseURI + entityName + "/" + MetadataSetDefaultVersionRequest.PATH_PARAM_SET_DEFAULT_VERSION);
-		request.setBody(body);
-		HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataSetDefaultVersionRequestWithEntityName() throws UnsupportedEncodingException {
+        MetadataSetDefaultVersionRequest request = new MetadataSetDefaultVersionRequest(entityName, null);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpPost expectedRequest = new HttpPost(baseURI + entityName + "/" + MetadataOperation.SET_DEFAULT_VERSION.getPathParam());
+        request.setBody(body);
+        HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataSetDefaultVersionRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
-		MetadataSetDefaultVersionRequest request = new MetadataSetDefaultVersionRequest(entityName, entityVersion);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpPost expectedRequest = new HttpPost(baseURI + entityName + "/" + entityVersion + "/" + MetadataSetDefaultVersionRequest.PATH_PARAM_SET_DEFAULT_VERSION);
-		request.setBody(body);
-		HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataSetDefaultVersionRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
+        MetadataSetDefaultVersionRequest request = new MetadataSetDefaultVersionRequest(entityName, entityVersion);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpPost expectedRequest = new HttpPost(baseURI + entityName + "/" + entityVersion + "/" + MetadataOperation.SET_DEFAULT_VERSION.getPathParam());
+        request.setBody(body);
+        HttpPost actualRequest = (HttpPost) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataUpdateEntityInfoRequest() throws UnsupportedEncodingException {
-		MetadataUpdateEntityInfoRequest request = new MetadataUpdateEntityInfoRequest();
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpPut expectedRequest = new HttpPut(baseURI);
-		request.setBody(body);
-		HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataUpdateEntityInfoRequest() throws UnsupportedEncodingException {
+        MetadataUpdateEntityInfoRequest request = new MetadataUpdateEntityInfoRequest();
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpPut expectedRequest = new HttpPut(baseURI);
+        request.setBody(body);
+        HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataUpdateEntityInfoRequestWithEntityName() throws UnsupportedEncodingException {
-		MetadataUpdateEntityInfoRequest request = new MetadataUpdateEntityInfoRequest(entityName, null);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpPut expectedRequest = new HttpPut(baseURI + entityName);
-		request.setBody(body);
-		HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataUpdateEntityInfoRequestWithEntityName() throws UnsupportedEncodingException {
+        MetadataUpdateEntityInfoRequest request = new MetadataUpdateEntityInfoRequest(entityName, null);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpPut expectedRequest = new HttpPut(baseURI + entityName);
+        request.setBody(body);
+        HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataUpdateEntityInfoRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
-		MetadataUpdateEntityInfoRequest request = new MetadataUpdateEntityInfoRequest(entityName, entityVersion);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpPut expectedRequest = new HttpPut(baseURI + entityName + "/" + entityVersion);
-		request.setBody(body);
-		HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataUpdateEntityInfoRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
+        MetadataUpdateEntityInfoRequest request = new MetadataUpdateEntityInfoRequest(entityName, entityVersion);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpPut expectedRequest = new HttpPut(baseURI + entityName + "/" + entityVersion);
+        request.setBody(body);
+        HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataUpdateSchemaStatusRequest() throws UnsupportedEncodingException {
-		MetadataUpdateSchemaStatusRequest request = new MetadataUpdateSchemaStatusRequest();
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpPut expectedRequest = new HttpPut(baseURI);
-		request.setBody(body);
-		HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataUpdateSchemaStatusRequest() throws UnsupportedEncodingException {
+        MetadataUpdateSchemaStatusRequest request = new MetadataUpdateSchemaStatusRequest();
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpPut expectedRequest = new HttpPut(baseURI);
+        request.setBody(body);
+        HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataUpdateSchemaStatusRequestWithEntityName() throws UnsupportedEncodingException {
-		MetadataUpdateSchemaStatusRequest request = new MetadataUpdateSchemaStatusRequest(entityName, null);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpPut expectedRequest = new HttpPut(baseURI + entityName);
-		request.setBody(body);
-		HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataUpdateSchemaStatusRequestWithEntityName() throws UnsupportedEncodingException {
+        MetadataUpdateSchemaStatusRequest request = new MetadataUpdateSchemaStatusRequest(entityName, null);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpPut expectedRequest = new HttpPut(baseURI + entityName);
+        request.setBody(body);
+        HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
-	@Test
-	public void testGetRestRequestWithMetadataUpdateSchemaStatusRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
-		MetadataUpdateSchemaStatusRequest request = new MetadataUpdateSchemaStatusRequest(entityName, entityVersion);
-		httpRequest = new LightblueHttpMetadataRequest(request);
-		HttpPut expectedRequest = new HttpPut(baseURI + entityName + "/" + entityVersion);
-		request.setBody(body);
-		HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
-		compareHttpRequestBase(expectedRequest, actualRequest);
-	}
+    @Test
+    public void testGetRestRequestWithMetadataUpdateSchemaStatusRequestWithEntityNameAndVersion() throws UnsupportedEncodingException {
+        MetadataUpdateSchemaStatusRequest request = new MetadataUpdateSchemaStatusRequest(entityName, entityVersion);
+        httpRequest = new LightblueHttpMetadataRequest(request);
+        HttpPut expectedRequest = new HttpPut(baseURI + entityName + "/" + entityVersion);
+        request.setBody(body);
+        HttpPut actualRequest = (HttpPut) httpRequest.getRestRequest(baseURI);
+        compareHttpRequestBase(expectedRequest, actualRequest);
+    }
 
 }


### PR DESCRIPTION
This touches a bunch of files, but it really only is swapping out string constants for enums for data and metadata operations. The real value in this change is that other implementations of the various operations could be created that reuse the enum values rather the more limiting instanceof checks.

This is a non-breaking change that is part of a larger change I am working on for https://github.com/lightblue-platform/lightblue-migrator/issues/142. For simplicity I have decided to break it up into individual PRs.