### PR TITLE
Cleanup request structure

### DIFF
--- a/core/src/main/java/com/redhat/lightblue/client/request/AbstractLightblueDataRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/AbstractLightblueDataRequest.java
@@ -9,6 +9,14 @@ public abstract class AbstractLightblueDataRequest extends AbstractLightblueRequ
     public static final String PATH_PARAM_DELETE = "delete";
     public static final String PATH_PARAM_FIND = "find";
 
+    public AbstractLightblueDataRequest() {
+        super();
+    }
+
+    public AbstractLightblueDataRequest(String entityName, String entityVersion) {
+        super(entityName, entityVersion);
+    }
+
     @Override
     public String getRestURI(String baseServiceURI) {
         StringBuilder requestURI = new StringBuilder();

--- a/core/src/main/java/com/redhat/lightblue/client/request/AbstractLightblueMetadataRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/AbstractLightblueMetadataRequest.java
@@ -2,7 +2,7 @@ package com.redhat.lightblue.client.request;
 
 import org.apache.commons.lang.StringUtils;
 
-public abstract class AbstractLightblueMetadataRequest extends AbstractLightblueRequest implements LightblueRequest {
+public abstract class AbstractLightblueMetadataRequest extends AbstractLightblueRequest {
     public static final String PATH_PARAM_GET_ENTITY_NAMES = "";
     public static final String PATH_PARAM_GET_ENTITY_VERSIONS = "";
     public static final String PATH_PARAM_GET_ENTITY_METADATA = "";
@@ -15,6 +15,25 @@ public abstract class AbstractLightblueMetadataRequest extends AbstractLightblue
     public static final String PATH_PARAM_SET_DEFAULT_VERSION = "default";
     public static final String PATH_PARAM_REMOVE_ENTITY = "";
     public static final String PATH_PARAM_CLEAR_DEFAULT_VERSION = "";
+
+    private String body;
+
+    @Override
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public AbstractLightblueMetadataRequest() {
+        super();
+    }
+
+    public AbstractLightblueMetadataRequest(String entityName, String entityVersion) {
+        super(entityName, entityVersion);
+    }
 
     @Override
     public String getRestURI(String baseServiceURI) {

--- a/core/src/main/java/com/redhat/lightblue/client/request/AbstractLightblueRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/AbstractLightblueRequest.java
@@ -10,7 +10,6 @@ public abstract class AbstractLightblueRequest implements LightblueRequest {
 
     private String entityName;
     private String entityVersion;
-    private String body;
 
     @Override
     public String getEntityName() {
@@ -22,11 +21,6 @@ public abstract class AbstractLightblueRequest implements LightblueRequest {
         return entityVersion;
     }
 
-    @Override
-    public String getBody() {
-        return body;
-    }
-
     public void setEntityName(String entityName) {
         this.entityName = entityName;
     }
@@ -35,8 +29,11 @@ public abstract class AbstractLightblueRequest implements LightblueRequest {
         this.entityVersion = entityVersion;
     }
 
-    public void setBody(String body) {
-        this.body = body;
+    public AbstractLightblueRequest() {}
+
+    public AbstractLightblueRequest(String entityName, String entityVersion) {
+        this.entityName = entityName;
+        this.entityVersion = entityVersion;
     }
 
     protected void appendToURI(StringBuilder restOfURI, String pathParam) {

--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataDeleteRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataDeleteRequest.java
@@ -7,12 +7,11 @@ public class DataDeleteRequest extends AbstractLightblueDataRequest {
     private Query queryExpression;
 
     public DataDeleteRequest() {
-
+        super();
     }
 
     public DataDeleteRequest(String entityName, String entityVersion) {
-        this.setEntityName(entityName);
-        this.setEntityVersion(entityVersion);
+        super(entityName, entityVersion);
     }
 
     public void where(Query queryExpression) {

--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataFindRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataFindRequest.java
@@ -1,12 +1,12 @@
 package com.redhat.lightblue.client.request.data;
 
+import java.util.Collection;
+import java.util.List;
+
 import com.redhat.lightblue.client.expression.query.Query;
 import com.redhat.lightblue.client.projection.Projection;
 import com.redhat.lightblue.client.request.AbstractLightblueDataRequest;
 import com.redhat.lightblue.client.request.SortCondition;
-
-import java.util.Collection;
-import java.util.List;
 
 public class DataFindRequest extends AbstractLightblueDataRequest {
 
@@ -17,12 +17,11 @@ public class DataFindRequest extends AbstractLightblueDataRequest {
     private Integer end;
 
     public DataFindRequest() {
-
+        super();
     }
 
     public DataFindRequest(String entityName, String entityVersion) {
-        this.setEntityName(entityName);
-        this.setEntityVersion(entityVersion);
+        super(entityName, entityVersion);
     }
 
     public void where(Query queryExpression) {

--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataInsertRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataInsertRequest.java
@@ -12,12 +12,11 @@ public class DataInsertRequest extends AbstractLightblueDataRequest {
     private Object[] objects;
 
     public DataInsertRequest() {
-
+        super();
     }
 
     public DataInsertRequest(String entityName, String entityVersion) {
-        this.setEntityName(entityName);
-        this.setEntityVersion(entityVersion);
+        super(entityName, entityVersion);
     }
 
     public void returns(Projection... projection) {

--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataSaveRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataSaveRequest.java
@@ -13,12 +13,11 @@ public class DataSaveRequest extends AbstractLightblueDataRequest {
     private Boolean upsert;
 
     public DataSaveRequest() {
-
+        super();
     }
 
     public DataSaveRequest(String entityName, String entityVersion) {
-        this.setEntityName(entityName);
-        this.setEntityVersion(entityVersion);
+        super(entityName, entityVersion);
     }
 
     public void returns(Projection... projection) {

--- a/core/src/main/java/com/redhat/lightblue/client/request/data/DataUpdateRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/data/DataUpdateRequest.java
@@ -1,11 +1,11 @@
 package com.redhat.lightblue.client.request.data;
 
+import java.util.Collection;
+
 import com.redhat.lightblue.client.expression.query.Query;
 import com.redhat.lightblue.client.expression.update.Update;
 import com.redhat.lightblue.client.projection.Projection;
 import com.redhat.lightblue.client.request.AbstractLightblueDataRequest;
-
-import java.util.Collection;
 
 public class DataUpdateRequest extends AbstractLightblueDataRequest {
 
@@ -14,12 +14,11 @@ public class DataUpdateRequest extends AbstractLightblueDataRequest {
     private Query query;
 
     public DataUpdateRequest() {
-
+        super();
     }
 
     public DataUpdateRequest(String entityName, String entityVersion) {
-        this.setEntityName(entityName);
-        this.setEntityVersion(entityVersion);
+        super(entityName, entityVersion);
     }
 
     public void returns(Projection... projections) {

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataClearDefaultVersionRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataClearDefaultVersionRequest.java
@@ -5,12 +5,11 @@ import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest;
 public class MetadataClearDefaultVersionRequest extends AbstractLightblueMetadataRequest {
 
     public MetadataClearDefaultVersionRequest() {
-
+        super();
     }
 
     public MetadataClearDefaultVersionRequest(String entityName, String entityVersion) {
-        this.setEntityName(entityName);
-        this.setEntityVersion(entityVersion);
+        super(entityName, entityVersion);
     }
 
     @Override

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataCreateRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataCreateRequest.java
@@ -5,12 +5,11 @@ import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest;
 public class MetadataCreateRequest extends AbstractLightblueMetadataRequest {
 
     public MetadataCreateRequest() {
-
+        super();
     }
 
     public MetadataCreateRequest(String entityName, String entityVersion) {
-        this.setEntityName(entityName);
-        this.setEntityVersion(entityVersion);
+        super(entityName, entityVersion);
     }
 
     @Override

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataCreateSchemaRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataCreateSchemaRequest.java
@@ -5,12 +5,11 @@ import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest;
 public class MetadataCreateSchemaRequest extends AbstractLightblueMetadataRequest {
 
     public MetadataCreateSchemaRequest() {
-
+        super();
     }
 
     public MetadataCreateSchemaRequest(String entityName, String entityVersion) {
-        this.setEntityName(entityName);
-        this.setEntityVersion(entityVersion);
+        super(entityName, entityVersion);
     }
 
     @Override

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataGetEntityDependenciesRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataGetEntityDependenciesRequest.java
@@ -5,12 +5,11 @@ import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest;
 public class MetadataGetEntityDependenciesRequest extends AbstractLightblueMetadataRequest {
 
     public MetadataGetEntityDependenciesRequest() {
-
+        super();
     }
 
     public MetadataGetEntityDependenciesRequest(String entityName, String entityVersion) {
-        this.setEntityName(entityName);
-        this.setEntityVersion(entityVersion);
+        super(entityName, entityVersion);
     }
 
     @Override

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataGetEntityMetadataRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataGetEntityMetadataRequest.java
@@ -5,12 +5,11 @@ import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest;
 public class MetadataGetEntityMetadataRequest extends AbstractLightblueMetadataRequest {
 
     public MetadataGetEntityMetadataRequest() {
-
+        super();
     }
 
     public MetadataGetEntityMetadataRequest(String entityName, String entityVersion) {
-        this.setEntityName(entityName);
-        this.setEntityVersion(entityVersion);
+        super(entityName, entityVersion);
     }
 
     @Override

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataGetEntityNamesRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataGetEntityNamesRequest.java
@@ -5,12 +5,11 @@ import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest;
 public class MetadataGetEntityNamesRequest extends AbstractLightblueMetadataRequest {
 
     public MetadataGetEntityNamesRequest() {
-
+        super();
     }
 
     public MetadataGetEntityNamesRequest(String entityName, String entityVersion) {
-        this.setEntityName(entityName);
-        this.setEntityVersion(entityVersion);
+        super(entityName, entityVersion);
     }
 
     @Override

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataGetEntityRolesRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataGetEntityRolesRequest.java
@@ -5,12 +5,11 @@ import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest;
 public class MetadataGetEntityRolesRequest extends AbstractLightblueMetadataRequest {
 
     public MetadataGetEntityRolesRequest() {
-
+        super();
     }
 
     public MetadataGetEntityRolesRequest(String entityName, String entityVersion) {
-        this.setEntityName(entityName);
-        this.setEntityVersion(entityVersion);
+        super(entityName, entityVersion);
     }
 
     @Override

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataGetEntityVersionsRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataGetEntityVersionsRequest.java
@@ -5,12 +5,11 @@ import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest;
 public class MetadataGetEntityVersionsRequest extends AbstractLightblueMetadataRequest {
 
     public MetadataGetEntityVersionsRequest() {
-
+        super();
     }
 
     public MetadataGetEntityVersionsRequest(String entityName, String entityVersion) {
-        this.setEntityName(entityName);
-        this.setEntityVersion(entityVersion);
+        super(entityName, entityVersion);
     }
 
     @Override

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataRemoveEntityRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataRemoveEntityRequest.java
@@ -5,12 +5,11 @@ import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest;
 public class MetadataRemoveEntityRequest extends AbstractLightblueMetadataRequest {
 
     public MetadataRemoveEntityRequest() {
-
+        super();
     }
 
     public MetadataRemoveEntityRequest(String entityName, String entityVersion) {
-        this.setEntityName(entityName);
-        this.setEntityVersion(entityVersion);
+        super(entityName, entityVersion);
     }
 
     @Override

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataSetDefaultVersionRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataSetDefaultVersionRequest.java
@@ -5,12 +5,11 @@ import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest;
 public class MetadataSetDefaultVersionRequest extends AbstractLightblueMetadataRequest {
 
     public MetadataSetDefaultVersionRequest() {
-
+        super();
     }
 
     public MetadataSetDefaultVersionRequest(String entityName, String entityVersion) {
-        this.setEntityName(entityName);
-        this.setEntityVersion(entityVersion);
+        super(entityName, entityVersion);
     }
 
     @Override

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataUpdateEntityInfoRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataUpdateEntityInfoRequest.java
@@ -5,12 +5,11 @@ import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest;
 public class MetadataUpdateEntityInfoRequest extends AbstractLightblueMetadataRequest {
 
     public MetadataUpdateEntityInfoRequest() {
-
+        super();
     }
 
     public MetadataUpdateEntityInfoRequest(String entityName, String entityVersion) {
-        this.setEntityName(entityName);
-        this.setEntityVersion(entityVersion);
+        super(entityName, entityVersion);
     }
 
     @Override

--- a/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataUpdateSchemaStatusRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/metadata/MetadataUpdateSchemaStatusRequest.java
@@ -5,12 +5,11 @@ import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest;
 public class MetadataUpdateSchemaStatusRequest extends AbstractLightblueMetadataRequest {
 
     public MetadataUpdateSchemaStatusRequest() {
-
+        super();
     }
 
     public MetadataUpdateSchemaStatusRequest(String entityName, String entityVersion) {
-        this.setEntityName(entityName);
-        this.setEntityVersion(entityVersion);
+        super(entityName, entityVersion);
     }
 
     @Override

--- a/core/src/test/java/com/redhat/lightblue/client/request/TestAbstractLightblueDataRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/TestAbstractLightblueDataRequest.java
@@ -1,29 +1,27 @@
 package com.redhat.lightblue.client.request;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 public class TestAbstractLightblueDataRequest extends AbstractLightblueRequestTest {
 
-		
-	AbstractLightblueDataRequest testRequest = new AbstractLightblueDataRequest() {
+    AbstractLightblueDataRequest testRequest = new AbstractLightblueDataRequest(entityName, entityVersion) {
 
-		@Override
-    public String getOperationPathParam() {
-	    return dataOperation;
+        @Override
+        public String getOperationPathParam() {
+            return dataOperation;
+        }
+
+        @Override
+        public String getBody() {
+            // TODO Auto-generated method stub
+            return null;
+        }
+    };
+
+    @Test
+    public void testGetRestURI() {
+        Assert.assertEquals(finalDataURI, testRequest.getRestURI(baseURI));
     }
-	};
-		
-	@Before
-	public void setUp() throws Exception {
-		testRequest.setEntityName(entityName);
-		testRequest.setEntityVersion(entityVersion);
-	}
-
-	@Test
-	public void testGetRestURI() {
-		Assert.assertEquals(finalDataURI, testRequest.getRestURI(baseURI));
-	}
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/request/TestAbstractLightblueDataRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/TestAbstractLightblueDataRequest.java
@@ -14,7 +14,6 @@ public class TestAbstractLightblueDataRequest extends AbstractLightblueRequestTe
 
         @Override
         public String getBody() {
-            // TODO Auto-generated method stub
             return null;
         }
     };

--- a/core/src/test/java/com/redhat/lightblue/client/request/TestAbstractLightblueRequest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/request/TestAbstractLightblueRequest.java
@@ -6,79 +6,83 @@ import org.junit.Test;
 
 public class TestAbstractLightblueRequest extends AbstractLightblueRequestTest {
 
-	AbstractLightblueRequest testRequest = new AbstractLightblueRequest() {
+    private static class MockAbstractLightblueRequest extends AbstractLightblueRequest {
         private String body;
-		@Override
-		public String getRestURI(String baseServiceURI) {
-			return null;
-		}
 
-		@Override
-		public String getOperationPathParam() {
-			return null;
-		}
+        @Override
+        public String getRestURI(String baseServiceURI) {
+            return null;
+        }
+
+        @Override
+        public String getOperationPathParam() {
+            return null;
+        }
 
         public void setBody(String body) {
             this.body = body;
         }
 
+        @Override
         public String getBody() {
             return body;
         }
-	};
+    }
 
-	private static final String updatedEntityName = "updatedEntity";
-	private static final String updatedEntityVersion = "3.2.1";
-	private static final String updatedBody = "{\"value\":\"name\"}";
-	private static final String baseURI = "http://lightblue.io";
-	private static final String restURI = "http://lightblue.io/rest";
+    MockAbstractLightblueRequest testRequest = new MockAbstractLightblueRequest();
 
-	@Before
-	public void setUp() throws Exception {
-		testRequest.setEntityName(entityName);
-		testRequest.setEntityVersion(entityVersion);
-		testRequest.setBody(body);
-	}
+    private static final String updatedEntityName = "updatedEntity";
+    private static final String updatedEntityVersion = "3.2.1";
+    private static final String updatedBody = "{\"value\":\"name\"}";
+    private static final String baseURI = "http://lightblue.io";
+    private static final String restURI = "http://lightblue.io/rest";
 
-	@Test
-	public void testGetEntityName() {
-		Assert.assertEquals(entityName, testRequest.getEntityName());
-	}
+    @Before
+    public void setUp() throws Exception {
+        testRequest.setEntityName(entityName);
+        testRequest.setEntityVersion(entityVersion);
+        testRequest.setBody(body);
+    }
 
-	@Test
-	public void testGetEntityVersion() {
-		Assert.assertEquals(entityVersion, testRequest.getEntityVersion());
-	}
+    @Test
+    public void testGetEntityName() {
+        Assert.assertEquals(entityName, testRequest.getEntityName());
+    }
 
-	@Test
-	public void testGetBody() {
-		Assert.assertEquals(body, testRequest.getBody());
-	}
+    @Test
+    public void testGetEntityVersion() {
+        Assert.assertEquals(entityVersion, testRequest.getEntityVersion());
+    }
 
-	@Test
-	public void testSetEntityName() {
-		testRequest.setEntityName(updatedEntityName);
-		Assert.assertEquals(updatedEntityName, testRequest.getEntityName());
-	}
+    @Test
+    public void testGetBody() {
+        Assert.assertEquals(body, testRequest.getBody());
+    }
 
-	@Test
-	public void testSetEntityVersion() {
-		testRequest.setEntityVersion(updatedEntityVersion);
-		Assert.assertEquals(updatedEntityVersion, testRequest.getEntityVersion());
-	}
+    @Test
+    public void testSetEntityName() {
+        testRequest.setEntityName(updatedEntityName);
+        Assert.assertEquals(updatedEntityName, testRequest.getEntityName());
+    }
 
-	@Test
-	public void testSetBody() {
-		testRequest.setBody(updatedBody);
-		Assert.assertEquals(updatedBody, testRequest.getBody());
-	}
+    @Test
+    public void testSetEntityVersion() {
+        testRequest.setEntityVersion(updatedEntityVersion);
+        Assert.assertEquals(updatedEntityVersion, testRequest.getEntityVersion());
+    }
 
-	@Test
-	public void testAppendToURI() {
-		StringBuilder initialURI = new StringBuilder();
-		initialURI.append(baseURI);
-		testRequest.appendToURI(initialURI, "rest");
-		Assert.assertEquals(restURI, initialURI.toString());
-	}
-	
+    @Test
+    public void testSetBody() {
+        testRequest.setBody(updatedBody);
+        Assert.assertEquals(updatedBody, testRequest.getBody());
+    }
+
+    @Test
+    public void testAppendToURI() {
+        StringBuilder initialURI = new StringBuilder();
+        initialURI.append(baseURI);
+        testRequest.appendToURI(initialURI, "rest");
+        Assert.assertEquals(restURI, initialURI.toString());
+    }
+
 }


### PR DESCRIPTION
This fixes an issue where you could call the setBody method, but it would effectively be ignored because getBody was overridden. To me, this is unexpected behaviour and a bug. This also adds a constructor to AbstractLightblueRequest that allows the entityName and entityVersion to be passed up as opposed to implementations having to fend for themselves and creating duplicated logic.