### PR TITLE
better datatype enforcement

### DIFF
--- a/core/src/main/java/com/redhat/lightblue/client/LightblueClient.java
+++ b/core/src/main/java/com/redhat/lightblue/client/LightblueClient.java
@@ -1,16 +1,17 @@
 package com.redhat.lightblue.client;
 
-import com.redhat.lightblue.client.request.LightblueRequest;
-import com.redhat.lightblue.client.response.LightblueResponse;
-
 import java.io.IOException;
+
+import com.redhat.lightblue.client.request.AbstractLightblueDataRequest;
+import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest;
+import com.redhat.lightblue.client.response.LightblueResponse;
 
 public interface LightblueClient {
 
-    public abstract LightblueResponse metadata(LightblueRequest lightblueRequest);
+    public abstract LightblueResponse metadata(AbstractLightblueMetadataRequest lightblueRequest);
 
-    public abstract LightblueResponse data(LightblueRequest lightblueRequest);
+    public abstract LightblueResponse data(AbstractLightblueDataRequest lightblueRequest);
 
-    public abstract <T> T data(LightblueRequest lightblueRequest, Class<T> type) throws IOException;
+    public abstract <T> T data(AbstractLightblueDataRequest lightblueRequest, Class<T> type) throws IOException;
 
 }

--- a/http/src/main/java/com/redhat/lightblue/client/http/LightblueHttpClient.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/LightblueHttpClient.java
@@ -21,7 +21,8 @@ import com.redhat.lightblue.client.http.auth.HttpClientCertAuth;
 import com.redhat.lightblue.client.http.auth.HttpClientNoAuth;
 import com.redhat.lightblue.client.http.request.LightblueHttpDataRequest;
 import com.redhat.lightblue.client.http.request.LightblueHttpMetadataRequest;
-import com.redhat.lightblue.client.request.LightblueRequest;
+import com.redhat.lightblue.client.request.AbstractLightblueDataRequest;
+import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest;
 import com.redhat.lightblue.client.response.LightblueResponse;
 import com.redhat.lightblue.client.response.LightblueResponseParseException;
 import com.redhat.lightblue.client.util.JSON;
@@ -104,7 +105,7 @@ public class LightblueHttpClient implements LightblueClient {
      * .client.request.LightblueRequest)
      */
     @Override
-    public LightblueResponse metadata(LightblueRequest lightblueRequest) {
+    public LightblueResponse metadata(AbstractLightblueMetadataRequest lightblueRequest) {
         LOGGER.debug("Calling metadata service with lightblueRequest: " + lightblueRequest.toString());
         return callService(new LightblueHttpMetadataRequest(lightblueRequest)
                 .getRestRequest(configuration.getMetadataServiceURI()));
@@ -118,7 +119,7 @@ public class LightblueHttpClient implements LightblueClient {
      * .request.LightblueRequest)
      */
     @Override
-    public LightblueResponse data(LightblueRequest lightblueRequest) {
+    public LightblueResponse data(AbstractLightblueDataRequest lightblueRequest) {
         LOGGER.debug("Calling data service with lightblueRequest: " + lightblueRequest.toString());
         try {
             return callService(new LightblueHttpDataRequest(lightblueRequest)
@@ -129,7 +130,7 @@ public class LightblueHttpClient implements LightblueClient {
     }
 
     @Override
-    public <T> T data(LightblueRequest lightblueRequest, Class<T> type) throws IOException {
+    public <T> T data(AbstractLightblueDataRequest lightblueRequest, Class<T> type) throws IOException {
         LightblueResponse response = data(lightblueRequest);
         try {
             return response.parseProcessed(type);

--- a/http/src/main/java/com/redhat/lightblue/client/http/request/LightblueHttpDataRequest.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/request/LightblueHttpDataRequest.java
@@ -2,7 +2,7 @@ package com.redhat.lightblue.client.http.request;
 
 import org.apache.http.client.methods.HttpRequestBase;
 
-import com.redhat.lightblue.client.request.LightblueRequest;
+import com.redhat.lightblue.client.request.AbstractLightblueDataRequest;
 import com.redhat.lightblue.client.request.data.DataDeleteRequest;
 import com.redhat.lightblue.client.request.data.DataFindRequest;
 import com.redhat.lightblue.client.request.data.DataInsertRequest;
@@ -11,28 +11,28 @@ import com.redhat.lightblue.client.request.data.DataUpdateRequest;
 
 public class LightblueHttpDataRequest extends AbstractLightblueHttpRequest implements LightblueHttpRequest {
 
-	LightblueRequest request;
-	
-	public LightblueHttpDataRequest(LightblueRequest request) {
-		this.request = request;
-	}
-	
-	@Override
-	public HttpRequestBase getRestRequest(String baseServiceURI) {
-		HttpRequestBase httpRequest = null;
+    private final AbstractLightblueDataRequest request;
 
-		if (request instanceof DataDeleteRequest) {
-			return getHttpPost(request.getRestURI(baseServiceURI), request.getBody());
-		} else if (request instanceof DataFindRequest) {
-			return getHttpPost(request.getRestURI(baseServiceURI), request.getBody());
-		} else if (request instanceof DataInsertRequest) {
-			return getHttpPut(request.getRestURI(baseServiceURI), request.getBody());
-		} else if (request instanceof DataSaveRequest) {
-			return getHttpPost(request.getRestURI(baseServiceURI), request.getBody());
-		} else if (request instanceof DataUpdateRequest) {
-			return getHttpPost(request.getRestURI(baseServiceURI), request.getBody());
-		}
-		return httpRequest;
-	}
+    public LightblueHttpDataRequest(AbstractLightblueDataRequest request) {
+        this.request = request;
+    }
+
+    @Override
+    public HttpRequestBase getRestRequest(String baseServiceURI) {
+        HttpRequestBase httpRequest = null;
+
+        if (request instanceof DataDeleteRequest) {
+            return getHttpPost(request.getRestURI(baseServiceURI), request.getBody());
+        } else if (request instanceof DataFindRequest) {
+            return getHttpPost(request.getRestURI(baseServiceURI), request.getBody());
+        } else if (request instanceof DataInsertRequest) {
+            return getHttpPut(request.getRestURI(baseServiceURI), request.getBody());
+        } else if (request instanceof DataSaveRequest) {
+            return getHttpPost(request.getRestURI(baseServiceURI), request.getBody());
+        } else if (request instanceof DataUpdateRequest) {
+            return getHttpPost(request.getRestURI(baseServiceURI), request.getBody());
+        }
+        return httpRequest;
+    }
 
 }

--- a/http/src/main/java/com/redhat/lightblue/client/http/request/LightblueHttpMetadataRequest.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/request/LightblueHttpMetadataRequest.java
@@ -2,7 +2,7 @@ package com.redhat.lightblue.client.http.request;
 
 import org.apache.http.client.methods.HttpRequestBase;
 
-import com.redhat.lightblue.client.request.LightblueRequest;
+import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest;
 import com.redhat.lightblue.client.request.metadata.MetadataClearDefaultVersionRequest;
 import com.redhat.lightblue.client.request.metadata.MetadataCreateRequest;
 import com.redhat.lightblue.client.request.metadata.MetadataCreateSchemaRequest;
@@ -18,42 +18,42 @@ import com.redhat.lightblue.client.request.metadata.MetadataUpdateSchemaStatusRe
 
 public class LightblueHttpMetadataRequest extends AbstractLightblueHttpRequest implements LightblueHttpRequest {
 
-	LightblueRequest request;
+    private final AbstractLightblueMetadataRequest request;
 
-	public LightblueHttpMetadataRequest(LightblueRequest request) {
-		this.request = request;
-	}
+    public LightblueHttpMetadataRequest(AbstractLightblueMetadataRequest request) {
+        this.request = request;
+    }
 
-	@Override
-	public HttpRequestBase getRestRequest(String baseServiceURI) {
-		HttpRequestBase httpRequest = null;
+    @Override
+    public HttpRequestBase getRestRequest(String baseServiceURI) {
+        HttpRequestBase httpRequest = null;
 
-		if (request instanceof MetadataClearDefaultVersionRequest) {
-			return getHttpDelete(request.getRestURI(baseServiceURI));
-		} else if (request instanceof MetadataCreateRequest) {
-			return getHttpPut(request.getRestURI(baseServiceURI), request.getBody());
-		} else if (request instanceof MetadataCreateSchemaRequest) {
-			return getHttpPut(request.getRestURI(baseServiceURI), request.getBody());
-		} else if (request instanceof MetadataGetEntityDependenciesRequest) {
-			return getHttpGet(request.getRestURI(baseServiceURI));
-		} else if (request instanceof MetadataGetEntityMetadataRequest) {
-			return getHttpGet(request.getRestURI(baseServiceURI));
-		} else if (request instanceof MetadataGetEntityNamesRequest) {
-			return getHttpGet(request.getRestURI(baseServiceURI));
-		} else if (request instanceof MetadataGetEntityRolesRequest) {
-			return getHttpGet(request.getRestURI(baseServiceURI));
-		} else if (request instanceof MetadataGetEntityVersionsRequest) {
-			return getHttpGet(request.getRestURI(baseServiceURI));
-		} else if (request instanceof MetadataRemoveEntityRequest) {
-			return getHttpDelete(request.getRestURI(baseServiceURI));
-		} else if (request instanceof MetadataSetDefaultVersionRequest) {
-			return getHttpPost(request.getRestURI(baseServiceURI), request.getBody());
-		} else if (request instanceof MetadataUpdateEntityInfoRequest) {
-			return getHttpPut(request.getRestURI(baseServiceURI), request.getBody());
-		} else if (request instanceof MetadataUpdateSchemaStatusRequest) {
-			return getHttpPut(request.getRestURI(baseServiceURI), request.getBody());
-		}
-		return httpRequest;
-	}
+        if (request instanceof MetadataClearDefaultVersionRequest) {
+            return getHttpDelete(request.getRestURI(baseServiceURI));
+        } else if (request instanceof MetadataCreateRequest) {
+            return getHttpPut(request.getRestURI(baseServiceURI), request.getBody());
+        } else if (request instanceof MetadataCreateSchemaRequest) {
+            return getHttpPut(request.getRestURI(baseServiceURI), request.getBody());
+        } else if (request instanceof MetadataGetEntityDependenciesRequest) {
+            return getHttpGet(request.getRestURI(baseServiceURI));
+        } else if (request instanceof MetadataGetEntityMetadataRequest) {
+            return getHttpGet(request.getRestURI(baseServiceURI));
+        } else if (request instanceof MetadataGetEntityNamesRequest) {
+            return getHttpGet(request.getRestURI(baseServiceURI));
+        } else if (request instanceof MetadataGetEntityRolesRequest) {
+            return getHttpGet(request.getRestURI(baseServiceURI));
+        } else if (request instanceof MetadataGetEntityVersionsRequest) {
+            return getHttpGet(request.getRestURI(baseServiceURI));
+        } else if (request instanceof MetadataRemoveEntityRequest) {
+            return getHttpDelete(request.getRestURI(baseServiceURI));
+        } else if (request instanceof MetadataSetDefaultVersionRequest) {
+            return getHttpPost(request.getRestURI(baseServiceURI), request.getBody());
+        } else if (request instanceof MetadataUpdateEntityInfoRequest) {
+            return getHttpPut(request.getRestURI(baseServiceURI), request.getBody());
+        } else if (request instanceof MetadataUpdateSchemaStatusRequest) {
+            return getHttpPut(request.getRestURI(baseServiceURI), request.getBody());
+        }
+        return httpRequest;
+    }
 
 }

--- a/hystrix/src/test/java/com/redhat/lightblue/client/hystrix/LightblueHystrixClientTest.java
+++ b/hystrix/src/test/java/com/redhat/lightblue/client/hystrix/LightblueHystrixClientTest.java
@@ -5,12 +5,15 @@
  */
 package com.redhat.lightblue.client.hystrix;
 
-import com.redhat.lightblue.client.LightblueClient;
-import com.redhat.lightblue.client.request.LightblueRequest;
-import com.redhat.lightblue.client.response.LightblueResponse;
 import java.io.IOException;
+
 import org.junit.Assert;
 import org.junit.Test;
+
+import com.redhat.lightblue.client.LightblueClient;
+import com.redhat.lightblue.client.request.AbstractLightblueDataRequest;
+import com.redhat.lightblue.client.request.AbstractLightblueMetadataRequest;
+import com.redhat.lightblue.client.response.LightblueResponse;
 
 /**
  *
@@ -26,19 +29,19 @@ public class LightblueHystrixClientTest {
         boolean dataType = false;
 
         @Override
-        public LightblueResponse metadata(LightblueRequest lightblueRequest) {
+        public LightblueResponse metadata(AbstractLightblueMetadataRequest lightblueRequest) {
             metadata = true;
             return null;
         }
 
         @Override
-        public LightblueResponse data(LightblueRequest lightblueRequest) {
+        public LightblueResponse data(AbstractLightblueDataRequest lightblueRequest) {
             data = true;
             return null;
         }
 
         @Override
-        public <T> T data(LightblueRequest lightblueRequest, Class<T> type) throws IOException {
+        public <T> T data(AbstractLightblueDataRequest lightblueRequest, Class<T> type) throws IOException {
             dataType = true;
             return null;
         }


### PR DESCRIPTION
The change enforces that only certain LightblueRequest hierarchies are passed into specific LightblueClient methods. As it is, any implementation of LightblueRequest is allowed, but if not of the correct family is essentially ignored. This is first of all confusing, and secondly requires casting if family centric functionality is required.