### PR TITLE
Setting content-type to 'application/json'

### DIFF
--- a/http/src/main/java/com/redhat/lightblue/client/http/servlet/AbstractLightblueProxyServlet.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/servlet/AbstractLightblueProxyServlet.java
@@ -188,6 +188,9 @@ public abstract class AbstractLightblueProxyServlet extends HttpServlet {
             HttpRequestWrapper wrappedRequest = HttpRequestWrapper.wrap(httpRequest);
             wrappedRequest.setURI(new URI(newUri));
 
+            // Somehow, content type header does not come in the original request either
+            wrappedRequest.setHeader("Content-Type", "application/json");
+
             return wrappedRequest;
         } catch (URISyntaxException e) {
             LOGGER.error("Syntax exception in service URI, " + newUri, e);

--- a/http/src/test/java/com/redhat/lightblue/client/http/servlet/AbstractLightblueProxyServletTest.java
+++ b/http/src/test/java/com/redhat/lightblue/client/http/servlet/AbstractLightblueProxyServletTest.java
@@ -75,7 +75,7 @@ public class AbstractLightblueProxyServletTest {
     }
 
     @Test
-    public void shouldProxyTheRequestMethodUriAndBody() throws ServletException, IOException, URISyntaxException {
+    public void shouldProxyTheRequestMethodUriBodyAndContentType() throws ServletException, IOException, URISyntaxException {
         CloseableHttpClient mockHttpClient = mock(CloseableHttpClient.class, Mockito.RETURNS_DEEP_STUBS);
 
         AbstractLightblueProxyServlet servlet = getTestServlet(mockHttpClient, null, "http://myservice.com", null);
@@ -98,6 +98,8 @@ public class AbstractLightblueProxyServletTest {
         assertEquals("GET", request.getMethod());
         assertEquals(new URI("http://myservice.com/the/thing?foo=bar"), request.getURI());
         assertThat(request, instanceOf(HttpEntityEnclosingRequest.class));
+        assertEquals(1, request.getHeaders("content-type").length);
+        assertEquals("application/json", request.getHeaders("content-type")[0].getValue());
 
         HttpEntityEnclosingRequest entityEnclosingRequest = (HttpEntityEnclosingRequest) request;
         ByteArrayOutputStream entityOutStream = new ByteArrayOutputStream();


### PR DESCRIPTION
GET requests work, but other methods fail. I see the content-type header being set in firebug, so I assume the proxy is to blame for not passing it down to lightblue.