### PR TITLE
Adding null value support to ValueQuery

### DIFF
--- a/core/src/test/java/com/redhat/lightblue/client/expression/query/ValueQueryTest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/expression/query/ValueQueryTest.java
@@ -80,4 +80,20 @@ public class ValueQueryTest {
     public void testInvalidExpressionUnrecognizedOperator() {
         new ValueQuery("field1 ~= Red Hat Enterprise Linux");
     }
+
+    @Test
+    public void testNullValue() throws JSONException {
+        ValueQuery expression = new ValueQuery("field1", ExpressionOperation.EQUALS, null);
+        String expectedJson = "{\"field\":\"field1\",\"op\":\"=\",\"rvalue\":null}";
+
+        JSONAssert.assertEquals(expectedJson, expression.toJson(), false);
+    }
+
+    @Test
+    public void testNullValueAmongInValues() throws JSONException {
+        ValueQuery expression = new ValueQuery("field1", NaryExpressionOperation.IN, "blah", null);
+        String expectedJson = "{\"field\":\"field1\",\"op\":\"$in\",\"values\":[\"blah\",null]}";
+        System.out.println(expression.toJson());
+        JSONAssert.assertEquals(expectedJson, expression.toJson(), false);
+    }
 }


### PR DESCRIPTION
So that it's possible to query by null values. Note that:
```java
withValue("field = null"}
```
will result in
```json
{
"field":"field",
"op":"=",
"rvalue": "null"
}
```
which is a "null", not a null.

To set a null value, you need to use the constructor:
```java
new ValueQuery("field1", ExpressionOperation.EQUALS, null);
```