### PR TITLE
add quick integration test for locking methods acquire and release

### DIFF
--- a/lightblue-client-integration-test/src/test/java/com/redhat/lightblue/client/integration/test/LockingTest.java
+++ b/lightblue-client-integration-test/src/test/java/com/redhat/lightblue/client/integration/test/LockingTest.java
@@ -1,0 +1,30 @@
+package com.redhat.lightblue.client.integration.test;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.redhat.lightblue.client.Locking;
+
+public class LockingTest extends AbstractLightblueClientCRUDController {
+
+    private static final String LOCK_DOMAIN = "test";
+
+    public LockingTest() throws Exception {
+        super();
+    }
+
+    @Override
+    protected JsonNode[] getMetadataJsonNodes() throws Exception {
+        return new JsonNode[]{};
+    }
+
+    @Test
+    public void testAcquireAndRelease() throws Exception {
+        Locking lbLocker = getLightblueClient().getLocking(LOCK_DOMAIN);
+        assertTrue(lbLocker.acquire("test-lock", 300000L));
+        assertTrue(lbLocker.release("test-lock"));
+    }
+
+}

--- a/lightblue-client-integration-test/src/test/resources/lightblue-crud.json
+++ b/lightblue-client-integration-test/src/test/resources/lightblue-crud.json
@@ -7,7 +7,7 @@
               "locking" : [
                   {
                       "domain":"test",
-                      "datasource":"mongo",
+                      "datasource":"${mongo.datasource}",
                       "collection":"locktest"
                   }
               ]


### PR DESCRIPTION
Just quickly adding an integration test to verify acquire and release are working via the client.