### PR TITLE
add Lightblue as ExternalResource

### DIFF
--- a/lightblue-client-integration-test/src/main/java/com/redhat/lightblue/client/integration/test/BeforeAfterTestRule.java
+++ b/lightblue-client-integration-test/src/main/java/com/redhat/lightblue/client/integration/test/BeforeAfterTestRule.java
@@ -1,0 +1,68 @@
+package com.redhat.lightblue.client.integration.test;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.internal.runners.statements.RunAfters;
+import org.junit.internal.runners.statements.RunBefores;
+import org.junit.rules.RunRules;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.junit.runners.model.TestClass;
+
+public class BeforeAfterTestRule implements TestRule {
+
+    private final TestClass[] extensions;
+
+    public BeforeAfterTestRule(TestClass... extensions) {
+        this.extensions = extensions;
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        //Create statement chain
+        Statement newStatement = base;
+        for (TestClass extension : extensions) {
+            newStatement = prepareBeforeClasses(extension, newStatement);
+            newStatement = prepareAfterClasses(extension, newStatement);
+            newStatement = prepareRules(extension, newStatement, description);
+            newStatement = prepareBefores(extension, newStatement, null);
+            newStatement = prepareAfters(extension, newStatement, null);
+        }
+
+        return newStatement;
+    }
+
+    protected Statement prepareBeforeClasses(TestClass extension, Statement base) {
+        return new RunBefores(
+                base, extension.getAnnotatedMethods(BeforeClass.class), null);
+    }
+
+    protected Statement prepareAfterClasses(TestClass extension, Statement base) {
+        return new RunAfters(
+                base, extension.getAnnotatedMethods(AfterClass.class), null);
+    }
+
+    protected Statement prepareBefores(TestClass extension, Statement base, Object target) {
+        return new RunBefores(
+                base, extension.getAnnotatedMethods(Before.class), target);
+    }
+
+    protected Statement prepareAfters(TestClass extension, Statement base, Object target) {
+        return new RunAfters(
+                base, extension.getAnnotatedMethods(After.class), target);
+    }
+
+    protected Statement prepareRules(TestClass extension, Statement base, Description description) {
+        List<TestRule> rules = extension.getAnnotatedFieldValues(null, Rule.class, TestRule.class);
+        rules.addAll(extension.getAnnotatedFieldValues(null, ClassRule.class, TestRule.class));
+        return new RunRules(base, rules, description);
+    }
+
+}

--- a/lightblue-client-integration-test/src/main/java/com/redhat/lightblue/client/integration/test/LightblueExternalResource.java
+++ b/lightblue-client-integration-test/src/main/java/com/redhat/lightblue/client/integration/test/LightblueExternalResource.java
@@ -1,0 +1,82 @@
+package com.redhat.lightblue.client.integration.test;
+
+import java.io.IOException;
+
+import org.junit.runners.model.TestClass;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.redhat.lightblue.client.LightblueClient;
+import com.redhat.lightblue.client.response.LightblueException;
+import com.redhat.lightblue.client.response.LightblueResponse;
+
+public class LightblueExternalResource extends BeforeAfterTestRule {
+
+    public interface LightblueTestMethods {
+        JsonNode[] getMetadataJsonNodes() throws Exception;
+    }
+
+    private final LightblueTestMethods methods;
+    private final int httpServerPort;
+
+    private ArtificialLightblueClientCRUDController controller;
+
+    public LightblueExternalResource(LightblueTestMethods methods) {
+        this(methods, 8000);
+    }
+
+    public LightblueExternalResource(LightblueTestMethods methods, Integer httpServerPort) {
+        super(new TestClass(ArtificialLightblueClientCRUDController.class));
+
+        if (methods == null) {
+            throw new IllegalArgumentException("Must provide an instance of LightblueTestMethods");
+        }
+        this.methods = methods;
+        this.httpServerPort = httpServerPort;
+    }
+
+    protected AbstractLightblueClientCRUDController getControllerInstance() {
+        if (controller == null) {
+            try {
+                controller = new ArtificialLightblueClientCRUDController(httpServerPort);
+            } catch (Exception e) {
+                throw new RuntimeException("Unable to create test CRUD Controller", e);
+            }
+        }
+        return controller;
+    }
+
+    public LightblueClient getLightblueClient() {
+        return getControllerInstance().getLightblueClient();
+    }
+
+    public LightblueResponse loadData(String entityName, String entityVersion, String resourcePath) throws IOException, LightblueException {
+        return getControllerInstance().loadData(entityName, entityVersion,
+                resourcePath);
+    }
+
+    public int getHttpPort() {
+        return getControllerInstance().getHttpPort();
+    }
+
+    public String getDataUrl() {
+        return getControllerInstance().getDataUrl();
+    }
+
+    public String getMetadataUrl() {
+        return getControllerInstance().getMetadataUrl();
+    }
+
+    private class ArtificialLightblueClientCRUDController extends AbstractLightblueClientCRUDController {
+
+        public ArtificialLightblueClientCRUDController(int httpServerPort) throws Exception {
+            super(httpServerPort);
+        }
+
+        @Override
+        protected JsonNode[] getMetadataJsonNodes() throws Exception {
+            return methods.getMetadataJsonNodes();
+        }
+
+    }
+
+}

--- a/lightblue-client-integration-test/src/test/java/com/redhat/lightblue/client/integration/test/TestLightblueExternalResource.java
+++ b/lightblue-client-integration-test/src/test/java/com/redhat/lightblue/client/integration/test/TestLightblueExternalResource.java
@@ -1,0 +1,53 @@
+package com.redhat.lightblue.client.integration.test;
+
+import static com.redhat.lightblue.util.test.AbstractJsonNodeTest.loadJsonNode;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.redhat.lightblue.client.LightblueClient;
+import com.redhat.lightblue.client.Projection;
+import com.redhat.lightblue.client.integration.test.LightblueExternalResource.LightblueTestMethods;
+import com.redhat.lightblue.client.integration.test.pojo.Country;
+import com.redhat.lightblue.client.request.data.DataInsertRequest;
+import com.redhat.lightblue.client.response.LightblueResponse;
+
+public class TestLightblueExternalResource {
+
+    private LightblueClient client;
+
+    @ClassRule
+    public static LightblueExternalResource lightblue = new LightblueExternalResource(new LightblueTestMethods() {
+
+        @Override
+        public JsonNode[] getMetadataJsonNodes() throws Exception {
+            return new JsonNode[]{loadJsonNode("./metadata/country.json")};
+        }
+
+    });
+
+    @Before
+    public void before() {
+        client = lightblue.getLightblueClient();
+    }
+
+    @Test
+    public void test() throws Exception {
+        Country c = new Country();
+        c.setName("Poland");
+        c.setIso2Code("PL");
+        c.setIso3Code("POL");
+
+        DataInsertRequest insert = new DataInsertRequest(Country.objectType, Country.objectVersion);
+        insert.create(c);
+        insert.returns(Projection.includeFieldRecursively("*"));
+
+        LightblueResponse insertResponse = client.data(insert);
+
+        assertEquals(1, insertResponse.parseModifiedCount());
+    }
+
+}


### PR DESCRIPTION
Allows Lightblue to run in-memory as an junit ExternalResource. This is valuable when duel inheritance is a problem.