### PR TITLE
Use Literal.values with boxed types instead primitives

### DIFF
--- a/core/src/main/java/com/redhat/lightblue/client/Literal.java
+++ b/core/src/main/java/com/redhat/lightblue/client/Literal.java
@@ -99,14 +99,21 @@ public class Literal extends ExpressionPart implements
         return new Literal(b);
     }
 
-    public static Literal[] values(Integer...v) {
+    public static Literal[] values(int...v) {
         Literal[] ret=new Literal[v.length];
         for(int i=0;i<ret.length;i++)
             ret[i]=Literal.value(v[i]);
         return ret;
     }
 
-    public static Literal[] values(Long...v) {
+    public static Literal[] values(long...v) {
+        Literal[] ret=new Literal[v.length];
+        for(int i=0;i<ret.length;i++)
+            ret[i]=Literal.value(v[i]);
+        return ret;
+    }
+
+    public static Literal[] numbers(Number...v) {
         Literal[] ret=new Literal[v.length];
         for(int i=0;i<ret.length;i++)
             ret[i]=Literal.value(v[i]);
@@ -119,7 +126,7 @@ public class Literal extends ExpressionPart implements
             ret[i]=Literal.value(v[i]);
         return ret;
     }
-    
+
     public static EmptyArray emptyArray() {
         return new EmptyArray();
     }
@@ -127,7 +134,7 @@ public class Literal extends ExpressionPart implements
     public static EmptyObject  emptyObject() {
         return new EmptyObject();
     }
-    
+
     public static JsonNode toJson(Literal[] arr) {
         ArrayNode node=JsonNodeFactory.instance.arrayNode();
         for(Literal x:arr)

--- a/core/src/main/java/com/redhat/lightblue/client/Literal.java
+++ b/core/src/main/java/com/redhat/lightblue/client/Literal.java
@@ -99,14 +99,14 @@ public class Literal extends ExpressionPart implements
         return new Literal(b);
     }
 
-    public static Literal[] values(int...v) {
+    public static Literal[] values(Integer...v) {
         Literal[] ret=new Literal[v.length];
         for(int i=0;i<ret.length;i++)
             ret[i]=Literal.value(v[i]);
         return ret;
     }
 
-    public static Literal[] values(long...v) {
+    public static Literal[] values(Long...v) {
         Literal[] ret=new Literal[v.length];
         for(int i=0;i<ret.length;i++)
             ret[i]=Literal.value(v[i]);


### PR DESCRIPTION
Long[] ids = ...
Query.in, Literal.values(ids) 

was causing 
The method values(int...) in the type Literal is not applicable for the arguments (Long[])