### PR TITLE
Fixing long handling in Literal

### DIFF
--- a/core/src/main/java/com/redhat/lightblue/client/Literal.java
+++ b/core/src/main/java/com/redhat/lightblue/client/Literal.java
@@ -91,6 +91,10 @@ public class Literal extends ExpressionPart implements
         return new Literal(i);
     }
 
+    public static Literal value(long l) {
+        return new Literal(l);
+    }
+
     public static Literal value(double d) {
         return new Literal(d);
     }

--- a/core/src/test/java/com/redhat/lightblue/client/LiteralTest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/LiteralTest.java
@@ -1,0 +1,21 @@
+package com.redhat.lightblue.client;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LiteralTest {
+
+    @Test
+    public void testLong() {
+        long longPrimitive = 1234567l;
+
+        Assert.assertEquals("1234567", Literal.value(longPrimitive).toJson().toString());
+        Assert.assertEquals("[1234567,-1234567]", Literal.toJson( Literal.values( new long[] { longPrimitive, -longPrimitive})).toString());
+
+        Long longObject = 1234567l;
+
+        Assert.assertEquals("1234567", Literal.value(longObject).toJson().toString());
+        Assert.assertEquals("[1234567,-1234567]", Literal.toJson(new Literal[] { Literal.value(longObject), Literal.value(-longObject) }).toString());
+    }
+
+}


### PR DESCRIPTION
Client is adding decimal point to literals created from long and lightblue does not like that.