### PR TITLE
Should always ask for least specific type you need

### DIFF
--- a/core/src/main/java/com/redhat/lightblue/client/request/AbstractDataBulkRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/AbstractDataBulkRequest.java
@@ -34,12 +34,17 @@ public abstract class AbstractDataBulkRequest<E extends AbstractLightblueRequest
     }
 
     /**
-     * Adds a collection of requests to the end of the current request chain.
+     * Adds a collection of requests to the end of the current request chain in iteration order.
+     *
+     * <p>As the order of responses depends on the order of requests, use a collection with a
+     * reliable iteration order if you need to get a specific response for a specific request by
+     * index. Otherwise, you can also retrieve the response for a specific request using
+     * {@link com.redhat.lightblue.client.response.LightblueBulkDataResponse#getResponse(LightblueRequest)}.
      *
      * @param requests
      * @return
      */
-    public AbstractDataBulkRequest<E> addAll(Collection<E> requests) {
+    public AbstractDataBulkRequest<E> addAll(Collection<? extends E> requests) {
         this.requests.addAll(requests);
         return this;
     }

--- a/core/src/main/java/com/redhat/lightblue/client/request/AbstractDataBulkRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/AbstractDataBulkRequest.java
@@ -4,6 +4,7 @@
 package com.redhat.lightblue.client.request;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -38,7 +39,7 @@ public abstract class AbstractDataBulkRequest<E extends AbstractLightblueRequest
      * @param requests
      * @return
      */
-    public AbstractDataBulkRequest<E> addAll(List<E> requests) {
+    public AbstractDataBulkRequest<E> addAll(Collection<E> requests) {
         this.requests.addAll(requests);
         return this;
     }


### PR DESCRIPTION
Only needs collection, so ask for collection. More or less the same
reason you don't put ArrayList in the parameter. You don't care what the
type is as long as it's a collection.

In consuming code I am trying to pass a map's keySet which is a Set.
Shouldn't have to convert it to a List first.