### PR TITLE
Updated core version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
         <sonar.projectName>lightblue-client</sonar.projectName>
         <rpm.install.basedir>/usr/share/jbossas/standalone/deployments</rpm.install.basedir>
 
-        <lightblue.core.version>1.9.0</lightblue.core.version>
+        <lightblue.core.version>1.10.0-SNAPSHOT</lightblue.core.version>
         <lightblue.rest.version>1.9.0</lightblue.rest.version>
     </properties>
 


### PR DESCRIPTION
Many projects depending on this client do not pull in specific versions of lightblue-core.  Version 1.9.0 has some bugs, this PR is to make sure when next client version is cut we get an updated dependency on core.