### PR TITLE
Issue #202 - Bulk Data Response now returns all responses reguardless of any lb errors

### DIFF
--- a/core/src/main/java/com/redhat/lightblue/client/response/BulkResponseException.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/BulkResponseException.java
@@ -1,0 +1,29 @@
+package com.redhat.lightblue.client.response;
+
+import java.util.Collections;
+import java.util.List;
+
+public class BulkResponseException extends LightblueException {
+
+    private static final long serialVersionUID = -1204842853642316889L;
+
+    private final LightblueBulkDataResponse bulkResponse;
+    private final List<? extends LightblueResponseException> exceptions;
+
+    public BulkResponseException(String message,
+            LightblueBulkDataResponse bulkResponse,
+            List<? extends LightblueResponseException> exceptions) {
+        super(message);
+        this.bulkResponse = bulkResponse;
+        this.exceptions = exceptions;
+    }
+
+    public LightblueBulkDataResponse getBulkResponse() {
+        return bulkResponse;
+    }
+
+    public List<? extends LightblueResponseException> getLightblueResponseExceptions() {
+        return Collections.unmodifiableList(exceptions);
+    }
+
+}

--- a/core/src/main/java/com/redhat/lightblue/client/response/DefaultLightblueBulkDataResponse.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/DefaultLightblueBulkDataResponse.java
@@ -1,6 +1,7 @@
 package com.redhat.lightblue.client.response;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -82,12 +83,12 @@ public class DefaultLightblueBulkDataResponse extends AbstractLightblueResponse 
 
     @Override
     public List<LightblueDataResponse> getResponses() {
-        return new ArrayList<>(responses.values());
+        return Collections.unmodifiableList(new ArrayList<>(responses.values()));
     }
 
     @Override
     public List<? extends AbstractLightblueRequest> getRequests() {
-        return requests;
+        return Collections.unmodifiableList(requests);
     }
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/response/DefaultLightblueBulkDataResponse.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/DefaultLightblueBulkDataResponse.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -89,6 +90,11 @@ public class DefaultLightblueBulkDataResponse extends AbstractLightblueResponse 
     @Override
     public List<? extends AbstractLightblueRequest> getRequests() {
         return Collections.unmodifiableList(requests);
+    }
+
+    @Override
+    public Set<Integer> getSeqNumbers() {
+        return Collections.unmodifiableSet(responses.keySet());
     }
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/response/DefaultLightblueBulkDataResponse.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/DefaultLightblueBulkDataResponse.java
@@ -32,6 +32,9 @@ public class DefaultLightblueBulkDataResponse extends AbstractLightblueResponse 
         requests = reqs.getRequests();
 
         JsonNode resps = getJson().get("responses");
+        if (resps == null) {
+            throw new LightblueParseException("Unable to parse 'responses' node.");
+        }
 
         List<LightblueResponseException> exceptions = new ArrayList<>();
 
@@ -61,7 +64,7 @@ public class DefaultLightblueBulkDataResponse extends AbstractLightblueResponse 
             }
         }
         else {
-            throw new LightblueParseException("Unparseable bulk data response: " + resps.toString());
+            throw new LightblueParseException("Unparseable bulk data 'responses' node: " + resps.toString());
         }
 
         if (!exceptions.isEmpty()) {

--- a/core/src/main/java/com/redhat/lightblue/client/response/DefaultLightblueBulkDataResponse.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/DefaultLightblueBulkDataResponse.java
@@ -23,11 +23,11 @@ public class DefaultLightblueBulkDataResponse extends AbstractLightblueResponse 
     private final Map<Integer, LightblueDataResponse> responses = new TreeMap<>();
     private final List<? extends AbstractLightblueRequest> requests;
 
-    public DefaultLightblueBulkDataResponse(String responseText, AbstractDataBulkRequest<? extends AbstractLightblueRequest> reqs) throws LightblueParseException, BulkResponseException {
+    public DefaultLightblueBulkDataResponse(String responseText, AbstractDataBulkRequest<? extends AbstractLightblueRequest> reqs) throws LightblueParseException, LightblueBulkResponseException {
         this(responseText, JSON.getDefaultObjectMapper(), reqs);
     }
 
-    public DefaultLightblueBulkDataResponse(String responseText, ObjectMapper mapper, AbstractDataBulkRequest<? extends AbstractLightblueRequest> reqs) throws LightblueParseException, BulkResponseException {
+    public DefaultLightblueBulkDataResponse(String responseText, ObjectMapper mapper, AbstractDataBulkRequest<? extends AbstractLightblueRequest> reqs) throws LightblueParseException, LightblueBulkResponseException {
         super(responseText, mapper);
         requests = reqs.getRequests();
 
@@ -65,7 +65,7 @@ public class DefaultLightblueBulkDataResponse extends AbstractLightblueResponse 
         }
 
         if (!exceptions.isEmpty()) {
-            throw new BulkResponseException("Errors returned in responses", this, exceptions);
+            throw new LightblueBulkResponseException("Errors returned in responses", this, exceptions);
         }
     }
 

--- a/core/src/main/java/com/redhat/lightblue/client/response/LightblueBulkDataErrorResponse.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/LightblueBulkDataErrorResponse.java
@@ -1,0 +1,42 @@
+package com.redhat.lightblue.client.response;
+
+import java.util.List;
+import java.util.SortedMap;
+
+public interface LightblueBulkDataErrorResponse extends LightblueBulkDataResponse {
+
+    /**
+     * @return A {@link SortedMap} of {@link LightblueDataResponse}s keyed off the sequence.
+     * Includes both successful and errored responses.
+     */
+    @Override
+    SortedMap<Integer, LightblueDataResponse> getSequencedResponses();
+
+    /**
+     * @return all the {@link LightblueDataResponse}s in a sequentially ordered {@link List}.
+     * Includes both successful and errored responses.
+     */
+    @Override
+    List<LightblueDataResponse> getResponses();
+
+    /**
+     * @return A {@link SortedMap} of successful {@link LightblueDataResponse}s keyed off the sequence.
+     */
+    SortedMap<Integer, LightblueDataResponse> getSequencedSuccessfulResponses();
+
+    /**
+     * @return all of the successful {@link LightblueDataResponse}s in a sequentially ordered {@link List}.
+     */
+    List<LightblueDataResponse> getSuccessfulResponses();
+
+    /**
+     * @return A {@link SortedMap} of errored {@link LightblueDataResponse}s keyed off the sequence.
+     */
+    SortedMap<Integer, LightblueDataResponse> getSequencedResponsesWithErrors();
+
+    /**
+     * @return all of the errored {@link LightblueDataResponse}s in a sequentially ordered {@link List}.
+     */
+    List<LightblueDataResponse> getResponsesWithErrors();
+
+}

--- a/core/src/main/java/com/redhat/lightblue/client/response/LightblueBulkDataResponse.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/LightblueBulkDataResponse.java
@@ -1,21 +1,38 @@
 package com.redhat.lightblue.client.response;
 
 import java.util.List;
-import java.util.Set;
+import java.util.SortedMap;
 
-import com.redhat.lightblue.client.request.AbstractLightblueRequest;
+import com.redhat.lightblue.client.request.AbstractLightblueDataRequest;
 import com.redhat.lightblue.client.request.LightblueRequest;
 
 public interface LightblueBulkDataResponse extends LightblueResponse {
 
+    /**
+     * @param lbr - {@link LightblueRequest}
+     * @return the corresponding {@link LightblueDataResponse} for the passed in {@link LightblueRequest}.
+     */
     LightblueDataResponse getResponse(LightblueRequest lbr);
 
+    /**
+     * @param seq - sequence number
+     * @return the corresponding {@link LightblueDataResponse} for the passed in <code>seq</code>.
+     */
     LightblueDataResponse getResponse(int seq);
 
+    /**
+     * @return all the {@link LightblueDataResponse}s in a sequentially ordered {@link List}.
+     */
     List<LightblueDataResponse> getResponses();
 
-    List<? extends AbstractLightblueRequest> getRequests();
+    /**
+     * @return the {@link AbstractLightblueDataRequest} that make up this {@link LightblueBulkDataResponse}.
+     */
+    List<? extends AbstractLightblueDataRequest> getRequests();
 
-    Set<Integer> getSeqNumbers();
+    /**
+     * @return A {@link SortedMap} of {@link LightblueDataResponse}s keyed off the sequence.
+     */
+    SortedMap<Integer, LightblueDataResponse> getSequencedResponses();
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/response/LightblueBulkDataResponse.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/LightblueBulkDataResponse.java
@@ -1,6 +1,7 @@
 package com.redhat.lightblue.client.response;
 
 import java.util.List;
+import java.util.Set;
 
 import com.redhat.lightblue.client.request.AbstractLightblueRequest;
 import com.redhat.lightblue.client.request.LightblueRequest;
@@ -14,5 +15,7 @@ public interface LightblueBulkDataResponse extends LightblueResponse {
     List<LightblueDataResponse> getResponses();
 
     List<? extends AbstractLightblueRequest> getRequests();
+
+    Set<Integer> getSeqNumbers();
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/response/LightblueBulkResponseException.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/LightblueBulkResponseException.java
@@ -1,50 +1,29 @@
 package com.redhat.lightblue.client.response;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 public class LightblueBulkResponseException extends LightblueException {
 
     private static final long serialVersionUID = -1204842853642316889L;
 
-    private final LightblueBulkDataResponse bulkResponse;
-    private final Map<Integer, LightblueResponseException> erroredResponses;
+    private final LightblueBulkDataErrorResponse bulkResponse;
+    private final Map<Integer, LightblueResponseException> erroredResponseExceptions;
 
     public LightblueBulkResponseException(String message,
-            LightblueBulkDataResponse bulkResponse,
-            Map<Integer, LightblueResponseException> erroredResponses) {
+            LightblueBulkDataErrorResponse bulkResponse,
+            Map<Integer, LightblueResponseException> erroredResponseExceptions) {
         super(message);
         this.bulkResponse = bulkResponse;
-        this.erroredResponses = erroredResponses;
+        this.erroredResponseExceptions = erroredResponseExceptions;
     }
 
-    public LightblueBulkDataResponse getBulkResponse() {
+    public LightblueBulkDataErrorResponse getBulkResponse() {
         return bulkResponse;
     }
 
     public Map<Integer, LightblueResponseException> getLightblueResponseExceptions() {
-        return Collections.unmodifiableMap(erroredResponses);
-    }
-
-    public SortedMap<Integer, LightblueDataResponse> getSuccessfulResponsesWithSeq() {
-        Set<Integer> successfulKeys = new HashSet<>(bulkResponse.getSeqNumbers());
-        successfulKeys.removeAll(erroredResponses.keySet());
-
-        SortedMap<Integer, LightblueDataResponse> responses = new TreeMap<>();
-        for (Integer seq : successfulKeys) {
-            responses.put(seq, bulkResponse.getResponse(seq));
-        }
-        return responses;
-    }
-
-    public List<LightblueDataResponse> getSuccessfulResponses() {
-        return Collections.unmodifiableList(new ArrayList<>(getSuccessfulResponsesWithSeq().values()));
+        return Collections.unmodifiableMap(erroredResponseExceptions);
     }
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/response/LightblueBulkResponseException.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/LightblueBulkResponseException.java
@@ -3,14 +3,14 @@ package com.redhat.lightblue.client.response;
 import java.util.Collections;
 import java.util.List;
 
-public class BulkResponseException extends LightblueException {
+public class LightblueBulkResponseException extends LightblueException {
 
     private static final long serialVersionUID = -1204842853642316889L;
 
     private final LightblueBulkDataResponse bulkResponse;
     private final List<? extends LightblueResponseException> exceptions;
 
-    public BulkResponseException(String message,
+    public LightblueBulkResponseException(String message,
             LightblueBulkDataResponse bulkResponse,
             List<? extends LightblueResponseException> exceptions) {
         super(message);

--- a/core/src/main/java/com/redhat/lightblue/client/response/LightblueBulkResponseException.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/LightblueBulkResponseException.java
@@ -1,29 +1,29 @@
 package com.redhat.lightblue.client.response;
 
 import java.util.Collections;
-import java.util.List;
+import java.util.Map;
 
 public class LightblueBulkResponseException extends LightblueException {
 
     private static final long serialVersionUID = -1204842853642316889L;
 
     private final LightblueBulkDataResponse bulkResponse;
-    private final List<? extends LightblueResponseException> exceptions;
+    private final Map<Integer, LightblueResponseException> erroredResponses;
 
     public LightblueBulkResponseException(String message,
             LightblueBulkDataResponse bulkResponse,
-            List<? extends LightblueResponseException> exceptions) {
+            Map<Integer, LightblueResponseException> erroredResponses) {
         super(message);
         this.bulkResponse = bulkResponse;
-        this.exceptions = exceptions;
+        this.erroredResponses = erroredResponses;
     }
 
     public LightblueBulkDataResponse getBulkResponse() {
         return bulkResponse;
     }
 
-    public List<? extends LightblueResponseException> getLightblueResponseExceptions() {
-        return Collections.unmodifiableList(exceptions);
+    public Map<Integer, LightblueResponseException> getLightblueResponseExceptions() {
+        return Collections.unmodifiableMap(erroredResponses);
     }
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/response/LightblueBulkResponseException.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/LightblueBulkResponseException.java
@@ -1,7 +1,13 @@
 package com.redhat.lightblue.client.response;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 public class LightblueBulkResponseException extends LightblueException {
 
@@ -24,6 +30,21 @@ public class LightblueBulkResponseException extends LightblueException {
 
     public Map<Integer, LightblueResponseException> getLightblueResponseExceptions() {
         return Collections.unmodifiableMap(erroredResponses);
+    }
+
+    public SortedMap<Integer, LightblueDataResponse> getSuccessfulResponsesWithSeq() {
+        Set<Integer> successfulKeys = new HashSet<>(bulkResponse.getSeqNumbers());
+        successfulKeys.removeAll(erroredResponses.keySet());
+
+        SortedMap<Integer, LightblueDataResponse> responses = new TreeMap<>();
+        for (Integer seq : successfulKeys) {
+            responses.put(seq, bulkResponse.getResponse(seq));
+        }
+        return responses;
+    }
+
+    public List<LightblueDataResponse> getSuccessfulResponses() {
+        return Collections.unmodifiableList(new ArrayList<>(getSuccessfulResponsesWithSeq().values()));
     }
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/response/TestDefaultLightblueBulkDataResponse.java
+++ b/core/src/test/java/com/redhat/lightblue/client/response/TestDefaultLightblueBulkDataResponse.java
@@ -1,21 +1,15 @@
 /**
- * 
+ *
  */
 package com.redhat.lightblue.client.response;
 
-import static org.junit.Assert.*;
-
-import java.util.ArrayList;
-import java.util.Arrays;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Before;
 import org.junit.Test;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.redhat.lightblue.client.Projection;
 import com.redhat.lightblue.client.Query;
-import com.redhat.lightblue.client.request.AbstractLightblueDataRequest;
 import com.redhat.lightblue.client.request.DataBulkRequest;
 import com.redhat.lightblue.client.request.data.DataFindRequest;
 import com.redhat.lightblue.client.util.JSON;
@@ -62,6 +56,16 @@ public class TestDefaultLightblueBulkDataResponse {
     @Test
     public void testGetResponse() {
         assertEquals(bulkResponse.getResponses().get(0), bulkResponse.getResponse(bulkRequest.getRequests().get(0)));
+    }
+
+    @Test(expected = LightblueParseException.class)
+    public void testConstructor_With_UnexpectedJson() throws Exception {
+        new DefaultLightblueBulkDataResponse("{}", new DataBulkRequest());
+    }
+
+    @Test(expected = LightblueParseException.class)
+    public void testConstructor_With_NonArrayResponses() throws Exception {
+        new DefaultLightblueBulkDataResponse("{\"responses\":\"notAnArray\"}", new DataBulkRequest());
     }
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/response/TestDefaultLightblueBulkDataResponse.java
+++ b/core/src/test/java/com/redhat/lightblue/client/response/TestDefaultLightblueBulkDataResponse.java
@@ -24,7 +24,7 @@ import com.redhat.lightblue.client.util.JSON;
  * @author bvulaj
  *
  */
-public class TestBulkResponse {
+public class TestDefaultLightblueBulkDataResponse {
 
     private DefaultLightblueBulkDataResponse bulkResponse;
     private DataBulkRequest bulkRequest;

--- a/core/src/test/java/com/redhat/lightblue/client/response/TestDefaultLightblueBulkDataResponse.java
+++ b/core/src/test/java/com/redhat/lightblue/client/response/TestDefaultLightblueBulkDataResponse.java
@@ -4,8 +4,10 @@
 package com.redhat.lightblue.client.response;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-import org.junit.Before;
+import java.util.Map;
+
 import org.junit.Test;
 
 import com.redhat.lightblue.client.Projection;
@@ -20,14 +22,11 @@ import com.redhat.lightblue.client.util.JSON;
  */
 public class TestDefaultLightblueBulkDataResponse {
 
-    private DefaultLightblueBulkDataResponse bulkResponse;
-    private DataBulkRequest bulkRequest;
     private static final String jsonResponse =
             "{\"responses\":[{\"seq\":0,\"response\":{\"status\":\"COMPLETE\",\"modifiedCount\":0,\"matchCount\":1,\"processed\":[{\"identity#\":1,\"entityName\":\"foo\",\"lastUpdateDate\":\"\",\"versionText\":\"1.0.0\",\"_id\":\"\",\"audits#\":5,\"objectType\":\"audit\"}]}},{\"seq\":1,\"response\":{\"status\":\"COMPLETE\",\"modifiedCount\":0,\"matchCount\":1,\"processed\":[{\"identity#\":1,\"entityName\":\"foo\",\"lastUpdateDate\":\"\",\"versionText\":\"1.0.0\",\"_id\":\"\",\"audits#\":5,\"objectType\":\"audit\"}]}}]}";
 
-    @Before
-    public void setUp() throws Exception {
-        bulkRequest = new DataBulkRequest();
+    private DefaultLightblueBulkDataResponse simpleSetUp() throws Exception {
+        DataBulkRequest bulkRequest = new DataBulkRequest();
 
         DataFindRequest dfr = new DataFindRequest("foo", "bar");
         dfr.select(Projection.includeField("*"));
@@ -40,22 +39,75 @@ public class TestDefaultLightblueBulkDataResponse {
         bulkRequest.add(dfr);
         bulkRequest.add(dfr2);
 
-        bulkResponse = new DefaultLightblueBulkDataResponse(jsonResponse, bulkRequest);
+        return new DefaultLightblueBulkDataResponse(jsonResponse, bulkRequest);
     }
 
     @Test
-    public void testGetText() {
-        assertEquals(jsonResponse, bulkResponse.getText());
+    public void testGetText() throws Exception {
+        assertEquals(jsonResponse, simpleSetUp().getText());
     }
 
     @Test
-    public void testGetJson() {
-        assertEquals(JSON.toJsonNode(jsonResponse), bulkResponse.getJson());
+    public void testGetJson() throws Exception {
+        assertEquals(JSON.toJsonNode(jsonResponse), simpleSetUp().getJson());
     }
 
     @Test
-    public void testGetResponse() {
-        assertEquals(bulkResponse.getResponses().get(0), bulkResponse.getResponse(bulkRequest.getRequests().get(0)));
+    public void testGetResponseByRequest() throws Exception {
+        DefaultLightblueBulkDataResponse bulkResponse = simpleSetUp();
+        assertEquals(bulkResponse.getResponses().get(0), bulkResponse.getResponse(bulkResponse.getRequests().get(0)));
+        assertEquals(bulkResponse.getResponses().get(1), bulkResponse.getResponse(bulkResponse.getRequests().get(1)));
+    }
+
+    @Test
+    public void testGetResponseBySeq() throws Exception {
+        DefaultLightblueBulkDataResponse bulkResponse = simpleSetUp();
+        assertEquals(bulkResponse.getResponses().get(0), bulkResponse.getResponse(0));
+        assertEquals(bulkResponse.getResponses().get(1), bulkResponse.getResponse(1));
+    }
+
+    @Test
+    public void testResponseWithError() throws LightblueParseException {
+        DataBulkRequest bulkRequest = new DataBulkRequest();
+
+        DataFindRequest dfr = new DataFindRequest("foo", "bar");
+        dfr.select(Projection.includeField("*"));
+        dfr.where(Query.regex("foo", "*", 0));
+
+        DataFindRequest dfrErrored = new DataFindRequest("fooled", "bar");
+        dfrErrored.select(Projection.includeField("*"));
+        dfrErrored.where(Query.regex("fooled", "*", 0));
+
+        DataFindRequest dfr2 = new DataFindRequest("fooz", "bar");
+        dfr2.select(Projection.includeField("*"));
+        dfr2.where(Query.regex("fooz", "*", 0));
+
+        bulkRequest.add(dfr);
+        bulkRequest.add(dfrErrored);
+        bulkRequest.add(dfr2);
+
+        String jsonResponseWithError =
+                "{\"responses\":["
+                + "{\"seq\":0,\"response\":{\"status\":\"COMPLETE\",\"modifiedCount\":0,\"matchCount\":1,\"processed\":[{\"identity#\":1,\"entityName\":\"foo\",\"lastUpdateDate\":\"\",\"versionText\":\"1.0.0\",\"_id\":\"\",\"audits#\":5,\"objectType\":\"audit\"}]}},"
+                + "{\"seq\":1,\"response\":{\"status\":\"ERROR\",\"modifiedCount\":0,\"matchCount\":0,\"errors\":[{\"context\":\"some context\",\"errorCode\":\"errCode\",\"msg\":\"some msg\",\"status\":\"ERROR\"}]}},"
+                + "{\"seq\":2,\"response\":{\"status\":\"COMPLETE\",\"modifiedCount\":0,\"matchCount\":1,\"processed\":[{\"identity#\":1,\"entityName\":\"foo\",\"lastUpdateDate\":\"\",\"versionText\":\"1.0.0\",\"_id\":\"\",\"audits#\":5,\"objectType\":\"audit\"}]}}"
+                + "]}";
+
+        try {
+            new DefaultLightblueBulkDataResponse(jsonResponseWithError, bulkRequest);
+        } catch (LightblueBulkResponseException e) {
+            //expected
+            LightblueBulkDataResponse bulkResponse = e.getBulkResponse();
+            assertNotNull(bulkResponse);
+            assertEquals(bulkResponse.getResponses().get(0), bulkResponse.getResponse(dfr));
+            assertEquals(bulkResponse.getResponses().get(1), bulkResponse.getResponse(dfrErrored));
+            assertEquals(bulkResponse.getResponses().get(2), bulkResponse.getResponse(dfr2));
+
+            Map<Integer, LightblueResponseException> erroredResponses = e.getLightblueResponseExceptions();
+            assertNotNull(erroredResponses);
+            assertEquals(1, erroredResponses.size());
+            assertEquals(bulkResponse.getResponses().get(1), erroredResponses.get(1).getLightblueResponse());
+        }
     }
 
     @Test(expected = LightblueParseException.class)
@@ -66,6 +118,11 @@ public class TestDefaultLightblueBulkDataResponse {
     @Test(expected = LightblueParseException.class)
     public void testConstructor_With_NonArrayResponses() throws Exception {
         new DefaultLightblueBulkDataResponse("{\"responses\":\"notAnArray\"}", new DataBulkRequest());
+    }
+
+    @Test(expected = LightblueParseException.class)
+    public void testConstructor_With_NonNumericSeq() throws Exception {
+        new DefaultLightblueBulkDataResponse("{\"responses\":[{\"seq\":\"notint\",\"response\":{}}]}", new DataBulkRequest());
     }
 
 }

--- a/http/src/main/java/com/redhat/lightblue/client/http/LightblueHttpClient.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/LightblueHttpClient.java
@@ -238,10 +238,13 @@ public class LightblueHttpClient implements LightblueClient, Closeable {
     public DefaultLightblueBulkDataResponse bulkData(AbstractDataBulkRequest<AbstractLightblueDataRequest> lightblueRequests) throws LightblueException {
         LOGGER.debug("Calling data service with lightblueRequest: {}", lightblueRequests.toString());
 
-        return new DefaultLightblueBulkDataResponse(
-                callService(lightblueRequests, configuration.getDataServiceURI()),
-                mapper,
-                lightblueRequests);
+        String response = callService(lightblueRequests, configuration.getDataServiceURI());
+
+        try {
+            return new DefaultLightblueBulkDataResponse(response, mapper, lightblueRequests);
+        } catch (LightblueParseException e) {
+            throw new LightblueParseException("Unable to parse response " + response, e);
+        }
     }
 
     @Override


### PR DESCRIPTION
See #202 for conversation about this fix.

This is a breaking change as DefaultLightblueBulkDataResponse now throws LightblueBulkResponseException instead of LightblueResponseException.

Also, seq exception now throws a LightblueParseException.