### PR TITLE
Add javadocs for client cert locations + more descriptive errors

### DIFF
--- a/core/src/main/java/com/redhat/lightblue/client/LightblueClientConfiguration.java
+++ b/core/src/main/java/com/redhat/lightblue/client/LightblueClientConfiguration.java
@@ -72,30 +72,34 @@ public class LightblueClientConfiguration {
     }
 
     /**
-     * @return classpath reference for the CA file used to authenticate the validity of
-     *         the LB server certificate
+     * @return Reference for the CA file used to authenticate the validity of
+     *         the LB server certificate.  Should either be on the classpath, or
+     *         prefixed with 'file://'.
      */
     public String getCaFilePath() {
         return caFilePath;
     }
 
     /**
-     * @param caFilePath classpath reference for the CA file used to authenticate the validity of
-     *                   the LB server certificate
+     * @param caFilePath Reference for the CA file used to authenticate the validity of
+     *         the LB server certificate.  Should either be on the classpath, or
+     *         prefixed with 'file://'.
      */
     public void setCaFilePath(String caFilePath) {
         this.caFilePath = caFilePath;
     }
 
     /**
-     * @return classpath reference for the private key of the LB client
+     * @return Reference for the private key of the LB client.  Should either be on the
+     *          classpath, or prefixed with 'file://'/
      */
     public String getCertFilePath() {
         return certFilePath;
     }
 
     /**
-     * @param certFilePath classpath reference for the private key of the LB client
+     * @param certFilePath Reference for the private key of the LB client.  Should either be on the
+     *          classpath, or prefixed with 'file://'/
      */
     public void setCertFilePath(String certFilePath) {
         this.certFilePath = certFilePath;

--- a/core/src/main/java/com/redhat/lightblue/client/LightblueClientConfiguration.java
+++ b/core/src/main/java/com/redhat/lightblue/client/LightblueClientConfiguration.java
@@ -71,18 +71,32 @@ public class LightblueClientConfiguration {
         this.useCertAuth = useCertAuth;
     }
 
+    /**
+     * @return classpath reference for the CA file used to authenticate the validity of
+     *         the LB server certificate
+     */
     public String getCaFilePath() {
         return caFilePath;
     }
 
+    /**
+     * @param caFilePath classpath reference for the CA file used to authenticate the validity of
+     *                   the LB server certificate
+     */
     public void setCaFilePath(String caFilePath) {
         this.caFilePath = caFilePath;
     }
 
+    /**
+     * @return classpath reference for the private key of the LB client
+     */
     public String getCertFilePath() {
         return certFilePath;
     }
 
+    /**
+     * @param certFilePath classpath reference for the private key of the LB client
+     */
     public void setCertFilePath(String certFilePath) {
         this.certFilePath = certFilePath;
         this.certAlias = FilenameUtils.getBaseName(this.certFilePath);

--- a/http/src/main/java/com/redhat/lightblue/client/http/auth/SslSocketFactories.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/auth/SslSocketFactories.java
@@ -14,6 +14,7 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Objects;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -105,6 +106,12 @@ public class SslSocketFactories {
             InputStream authCert, char[] authCertPassword,
             String authCertAlias) throws CertificateException, NoSuchAlgorithmException,
             KeyStoreException, IOException, UnrecoverableKeyException, KeyManagementException {
+        
+        Objects.requireNonNull(certAuthorityFile, "Could not load the CA cert file.  Please verify that " +
+                "the file is present, on the classpath, and configured with the correct value.");
+        Objects.requireNonNull(authCert, "Could not load the auth cert file.  Please verify that the" +
+                " file is present, on the classpath, and configured with the correct value.");
+
         X509Certificate cert = getCertificate(certAuthorityFile);
         KeyStore pkcs12KeyStore = getPkcs12KeyStore(authCert, authCertPassword);
         KeyStore sunKeyStore = getJksKeyStore(cert, pkcs12KeyStore, authCertAlias, authCertPassword);

--- a/http/src/main/java/com/redhat/lightblue/client/http/auth/SslSocketFactories.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/auth/SslSocketFactories.java
@@ -108,9 +108,11 @@ public class SslSocketFactories {
             KeyStoreException, IOException, UnrecoverableKeyException, KeyManagementException {
         
         Objects.requireNonNull(certAuthorityFile, "Could not load the CA cert file.  Please verify that " +
-                "the file is present, on the classpath, and configured with the correct value.");
-        Objects.requireNonNull(authCert, "Could not load the auth cert file.  Please verify that the" +
-                " file is present, on the classpath, and configured with the correct value.");
+                "the certificate file is on the classpath or defined on the file system using the 'file://'" +
+                "prefix.");
+        Objects.requireNonNull(authCert, "Could not load the auth cert file.  Please verify that " +
+                        "the certificate file is on the classpath or defined on the file system using the " +
+                        "'file://' prefix.");
 
         X509Certificate cert = getCertificate(certAuthorityFile);
         KeyStore pkcs12KeyStore = getPkcs12KeyStore(authCert, authCertPassword);


### PR DESCRIPTION
The method names for the private/CA cert paths don't really denote that they're supposed to be on the classpath, thought it might be helpful to make that a little more clear (tripped me up for a moment anyway).

Use the Java 7 Objects class to check for null value - let me know if LB has a standard way of doing this or isn't on 7.  Didn't see a source/target java compile version in the parent pom, would be happy to add one though.