### PR TITLE
use SslSocketFactory's classloader to find classpath certificate resources

### DIFF
--- a/http/src/main/java/com/redhat/lightblue/client/http/auth/SslSocketFactories.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/auth/SslSocketFactories.java
@@ -113,7 +113,7 @@ public class SslSocketFactories {
     }
 
     private static InputStream loadFile(String filePath) throws FileNotFoundException{
-        return loadFile(Thread.currentThread().getContextClassLoader(), filePath);
+        return loadFile(SslSocketFactories.class.getClassLoader(), filePath);
     }
 
     private static InputStream loadFile(ClassLoader classLoader, String filePath) throws FileNotFoundException{


### PR DESCRIPTION
See https://github.com/lightblue-platform/lightblue-client/issues/244 for description.  Was simple, so thought I might as well put it out there.