### PR TITLE
remove depreciated methods from LightblueErrorResponse

### DIFF
--- a/core/src/main/java/com/redhat/lightblue/client/response/DefaultLightblueDataResponse.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/DefaultLightblueDataResponse.java
@@ -51,30 +51,6 @@ public class DefaultLightblueDataResponse extends AbstractLightblueResponse impl
         return err != null && !(err instanceof NullNode) && err.size() > 0;
     }
 
-    @Deprecated
-    @Override
-    public boolean hasError() {
-        if (getJson() == null) {
-            return true;
-        }
-
-        JsonNode objectTypeNode = getJson().get("status");
-        if (objectTypeNode == null) {
-            return false;
-        }
-        JsonNode err = getJson().get("errors");
-        if (err != null && !(err instanceof NullNode)) {
-            return true;
-        }
-        err = getJson().get("dataErrors");
-        if (err != null && (err instanceof ArrayNode)) {
-            if (err.size() > 0) {
-                return true;
-            }
-        }
-        return objectTypeNode.textValue().equalsIgnoreCase("error") || objectTypeNode.textValue().equalsIgnoreCase("partial");
-    }
-
     @Override
     public boolean hasLightblueErrors() {
         if (getJson() == null) {
@@ -113,12 +89,6 @@ public class DefaultLightblueDataResponse extends AbstractLightblueResponse impl
             return null;
         }
         return list.toArray(new DataError[list.size()]);
-    }
-
-    @Deprecated
-    @Override
-    public Error[] getErrors() {
-        return getLightblueErrors();
     }
 
     @Override

--- a/core/src/main/java/com/redhat/lightblue/client/response/LightblueErrorResponse.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/LightblueErrorResponse.java
@@ -12,14 +12,6 @@ import com.redhat.lightblue.client.model.Error;
 public interface LightblueErrorResponse extends LightblueResponse {
 
     /**
-     * Use {@link #hasLightblueErrors()}. The fact that a {@link LightblueErrorResponse} was even returned indicates
-     * that some sort of error state exists. This method returns an answer that is already known.
-     * @return <code>true</code> if the response has either errors or data errors.
-     */
-    @Deprecated
-    boolean hasError();
-
-    /**
      * @return <code>true</code> if any data errors exist on this response, otherwise <code>false</code>.
      */
     boolean hasDataErrors();
@@ -28,12 +20,6 @@ public interface LightblueErrorResponse extends LightblueResponse {
      * @return <code>true</code> if any lightblue errors exist on this response, otherwise <code>false</code>.
      */
     boolean hasLightblueErrors();
-
-    /**
-     * Use {@link #getLightblueErrors()}
-     */
-    @Deprecated
-    Error[] getErrors();
 
     /**
      * @return returns any {@link Error}s on this response.


### PR DESCRIPTION
Originally part of #234, I am pulling this change out so it can be approved independently.