### PR TITLE
use jdk8 explicitply for lightblue-client-integration-test

### DIFF
--- a/lightblue-client-integration-test/pom.xml
+++ b/lightblue-client-integration-test/pom.xml
@@ -28,4 +28,18 @@
       </dependency>
   </dependencies>
   
+  <build>
+      <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <version>2.3.2</version>
+              <configuration>
+                  <source>1.8</source>
+                  <target>1.8</target>
+              </configuration>
+          </plugin>
+      </plugins>
+  </build>
+  
 </project>


### PR DESCRIPTION
Fixes an issue when attempting to run individual tests in an IDE.