### PR TITLE
fixes #317 - add support for RequestID header

### DIFF
--- a/core/src/main/java/com/redhat/lightblue/client/response/DefaultLightblueBulkDataResponse.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/DefaultLightblueBulkDataResponse.java
@@ -30,6 +30,10 @@ public class DefaultLightblueBulkDataResponse extends AbstractLightblueResponse 
     private SortedMap<Integer, LightblueDataResponse> responsesErrored;
     private final List<? extends CRUDRequest> requests;
 
+    public DefaultLightblueBulkDataResponse(String responseText, DataBulkRequest reqs) throws LightblueParseException, LightblueBulkResponseException, LightblueException {
+        this(responseText, null, JSON.getDefaultObjectMapper(), reqs);
+    }
+    
     public DefaultLightblueBulkDataResponse(String responseText, Map<String, List<String>> headers, DataBulkRequest reqs) throws LightblueParseException, LightblueBulkResponseException, LightblueException {
         this(responseText, headers, JSON.getDefaultObjectMapper(), reqs);
     }

--- a/core/src/main/java/com/redhat/lightblue/client/response/DefaultLightblueBulkDataResponse.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/DefaultLightblueBulkDataResponse.java
@@ -13,8 +13,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.redhat.lightblue.client.LightblueException;
-import com.redhat.lightblue.client.request.DataBulkRequest;
 import com.redhat.lightblue.client.request.CRUDRequest;
+import com.redhat.lightblue.client.request.DataBulkRequest;
 import com.redhat.lightblue.client.request.LightblueRequest;
 import com.redhat.lightblue.client.util.JSON;
 
@@ -24,16 +24,18 @@ import com.redhat.lightblue.client.util.JSON;
  */
 public class DefaultLightblueBulkDataResponse extends AbstractLightblueResponse implements LightblueBulkDataResponse, LightblueBulkDataErrorResponse {
 
+    private static final long serialVersionUID = -1083441917471937489L;
+
     private final SortedMap<Integer, LightblueDataResponse> responsesSuccessful = new TreeMap<>();
     private SortedMap<Integer, LightblueDataResponse> responsesErrored;
     private final List<? extends CRUDRequest> requests;
 
-    public DefaultLightblueBulkDataResponse(String responseText, DataBulkRequest reqs) throws LightblueParseException, LightblueBulkResponseException, LightblueException {
-        this(responseText, JSON.getDefaultObjectMapper(), reqs);
+    public DefaultLightblueBulkDataResponse(String responseText, Map<String, List<String>> headers, DataBulkRequest reqs) throws LightblueParseException, LightblueBulkResponseException, LightblueException {
+        this(responseText, headers, JSON.getDefaultObjectMapper(), reqs);
     }
 
-    public DefaultLightblueBulkDataResponse(String responseText, ObjectMapper mapper, DataBulkRequest reqs) throws LightblueParseException, LightblueBulkResponseException, LightblueException {
-        super(responseText, mapper);
+    public DefaultLightblueBulkDataResponse(String responseText, Map<String, List<String>> headers, ObjectMapper mapper, DataBulkRequest reqs) throws LightblueParseException, LightblueBulkResponseException, LightblueException {
+        super(responseText, headers, mapper);
         requests = reqs.getRequests();
 
         JsonNode resps = getJson().get("responses");

--- a/core/src/main/java/com/redhat/lightblue/client/response/DefaultLightblueDataResponse.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/DefaultLightblueDataResponse.java
@@ -2,6 +2,8 @@ package com.redhat.lightblue.client.response;
 
 import java.io.IOException;
 import java.lang.reflect.Array;
+import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -10,24 +12,34 @@ import com.redhat.lightblue.client.LightblueException;
 
 public class DefaultLightblueDataResponse extends AbstractLightblueResponse implements LightblueDataResponse {
 
-    public DefaultLightblueDataResponse(JsonNode responseNode)
+    private static final long serialVersionUID = 9125163307190941424L;
+
+    public DefaultLightblueDataResponse(JsonNode responseNode, Map<String, List<String>> headers)
             throws LightblueResponseException, LightblueException {
-        super(responseNode);
+        super(responseNode, headers);
     }
 
-    public DefaultLightblueDataResponse(JsonNode responseNode, ObjectMapper mapper)
+    public DefaultLightblueDataResponse(JsonNode responseNode, ObjectMapper mapper) throws LightblueResponseException, LightblueException {
+        super(responseNode, null, mapper);
+    }
+
+    public DefaultLightblueDataResponse(JsonNode responseNode, Map<String, List<String>> headers, ObjectMapper mapper)
             throws LightblueResponseException, LightblueException {
-        super(responseNode, mapper);
+        super(responseNode, headers, mapper);
     }
 
-    public DefaultLightblueDataResponse(String responseText)
-            throws LightblueParseException, LightblueResponseException, LightblueException {
-        super(responseText);
+    public DefaultLightblueDataResponse(String responseText) throws LightblueParseException, LightblueResponseException, LightblueException {
+        super(responseText, null);
     }
 
-    public DefaultLightblueDataResponse(String responseText, ObjectMapper mapper)
+    public DefaultLightblueDataResponse(String responseText, Map<String, List<String>> headers)
             throws LightblueParseException, LightblueResponseException, LightblueException {
-        super(responseText, mapper);
+        super(responseText, headers);
+    }
+
+    public DefaultLightblueDataResponse(String responseText, Map<String, List<String>> headers, ObjectMapper mapper)
+            throws LightblueParseException, LightblueResponseException, LightblueException {
+        super(responseText, headers, mapper);
     }
 
     @Override

--- a/core/src/main/java/com/redhat/lightblue/client/response/DefaultLightblueMetadataResponse.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/DefaultLightblueMetadataResponse.java
@@ -1,17 +1,22 @@
 package com.redhat.lightblue.client.response;
 
+import java.util.List;
+import java.util.Map;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.lightblue.client.LightblueException;
 import com.redhat.lightblue.client.util.JSON;
 
 public class DefaultLightblueMetadataResponse extends AbstractLightblueResponse implements LightblueMetadataResponse {
 
-    public DefaultLightblueMetadataResponse(String responseText) throws LightblueParseException, LightblueResponseException, LightblueException {
-        this(responseText, JSON.getDefaultObjectMapper());
+    private static final long serialVersionUID = -3347921128635969447L;
+
+    public DefaultLightblueMetadataResponse(String responseText, Map<String, List<String>> headers) throws LightblueParseException, LightblueResponseException, LightblueException {
+        this(responseText, headers, JSON.getDefaultObjectMapper());
     }
 
-    public DefaultLightblueMetadataResponse(String responseText, ObjectMapper mapper) throws LightblueParseException, LightblueResponseException, LightblueException {
-        super(responseText, mapper);
+    public DefaultLightblueMetadataResponse(String responseText, Map<String, List<String>> headers, ObjectMapper mapper) throws LightblueParseException, LightblueResponseException, LightblueException {
+        super(responseText, headers, mapper);
     }
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/response/LightblueErrorResponse.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/LightblueErrorResponse.java
@@ -29,8 +29,13 @@ public interface LightblueErrorResponse extends LightblueResponse {
     Error[] getLightblueErrors();
 
     /**
-     * @return returns any {@link DataError}s on this reponse.
+     * @return returns any {@link DataError}s on this response.
      */
     DataError[] getDataErrors();
+
+    /**]
+     * @return the value requestid from the lightblue session on which the error occurred.
+     */
+    String getRequestId();
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/response/LightblueResponse.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/LightblueResponse.java
@@ -1,5 +1,7 @@
 package com.redhat.lightblue.client.response;
 
+import java.util.List;
+
 import com.fasterxml.jackson.databind.JsonNode;
 
 /**
@@ -12,5 +14,7 @@ public interface LightblueResponse {
     String getText();
 
     JsonNode getJson();
+
+    List<String> getHeaderValues(String key);
 
 }

--- a/core/src/main/java/com/redhat/lightblue/client/response/LightblueResponseException.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/LightblueResponseException.java
@@ -3,6 +3,8 @@ package com.redhat.lightblue.client.response;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.commons.lang.StringUtils;
+
 import com.redhat.lightblue.client.LightblueException;
 import com.redhat.lightblue.client.model.DataError;
 import com.redhat.lightblue.client.model.Error;
@@ -66,7 +68,12 @@ public class LightblueResponseException extends LightblueException implements Li
     @Override
     public String getMessage() {
         if (lightblueResponse != null) {
-            return super.getMessage() + lightblueResponse.getText();
+            StringBuffer sb = new StringBuffer(super.getMessage());
+            if (!StringUtils.isEmpty(lightblueResponse.getRequestId())) {
+                sb.append(" RequestID:").append(lightblueResponse.getRequestId());
+            }
+            sb.append(' ').append(lightblueResponse.getText());
+            return sb.toString();
         } else {
             return super.getMessage();
         }

--- a/core/src/main/java/com/redhat/lightblue/client/response/LightblueResponseException.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/LightblueResponseException.java
@@ -70,7 +70,7 @@ public class LightblueResponseException extends LightblueException implements Li
         if (lightblueResponse != null) {
             StringBuffer sb = new StringBuffer(super.getMessage());
             if (!StringUtils.isEmpty(lightblueResponse.getRequestId())) {
-                sb.append(" RequestID:").append(lightblueResponse.getRequestId());
+                sb.append(" RequestID=").append(lightblueResponse.getRequestId());
             }
             sb.append(' ').append(lightblueResponse.getText());
             return sb.toString();

--- a/core/src/main/java/com/redhat/lightblue/client/response/lock/LockResponse.java
+++ b/core/src/main/java/com/redhat/lightblue/client/response/lock/LockResponse.java
@@ -1,5 +1,7 @@
 package com.redhat.lightblue.client.response.lock;
 
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -14,17 +16,19 @@ import com.redhat.lightblue.client.response.LightblueResponseException;
 
 public class LockResponse extends AbstractLightblueResponse {
 
+    private static final long serialVersionUID = -3529529347455807299L;
+
     private static final Pattern INVALID_LOCK = Pattern.compile(
             "^.*InvalidLockException: (.+)$");
 
-    public LockResponse(String responseText)
+    public LockResponse(String responseText, Map<String, List<String>> headers)
             throws LightblueParseException, LightblueResponseException, LockException, LightblueException {
-        super(responseText);
+        super(responseText, headers);
     }
 
-    public LockResponse(String responseText, ObjectMapper mapper)
+    public LockResponse(String responseText, Map<String, List<String>> headers, ObjectMapper mapper)
             throws LightblueParseException, LightblueResponseException, LockException, LightblueException {
-        super(responseText, mapper);
+        super(responseText, headers, mapper);
     }
 
     public boolean parseAsBoolean() throws LightblueParseException {

--- a/core/src/test/java/com/redhat/lightblue/client/response/TestDefaultLightblueBulkDataResponse.java
+++ b/core/src/test/java/com/redhat/lightblue/client/response/TestDefaultLightblueBulkDataResponse.java
@@ -53,7 +53,7 @@ public class TestDefaultLightblueBulkDataResponse {
         bulkRequest.add(dfr);
         bulkRequest.add(dfr2);
 
-        return new DefaultLightblueBulkDataResponse(jsonResponse, null, bulkRequest);
+        return new DefaultLightblueBulkDataResponse(jsonResponse, bulkRequest);
     }
 
     @Test
@@ -101,7 +101,7 @@ public class TestDefaultLightblueBulkDataResponse {
         bulkRequest.add(dfr2);
 
         try {
-            new DefaultLightblueBulkDataResponse(jsonResponseWithError, null, bulkRequest);
+            new DefaultLightblueBulkDataResponse(jsonResponseWithError, bulkRequest);
             fail();
         } catch (LightblueBulkResponseException e) {
             //expected
@@ -147,7 +147,7 @@ public class TestDefaultLightblueBulkDataResponse {
         bulkRequest.add(dfr2);
 
         try {
-            new DefaultLightblueBulkDataResponse(jsonResponseWithError, null, bulkRequest);
+            new DefaultLightblueBulkDataResponse(jsonResponseWithError, bulkRequest);
             fail();
         } catch (LightblueBulkResponseException e) {
             //expected
@@ -196,7 +196,7 @@ public class TestDefaultLightblueBulkDataResponse {
         bulkRequest.add(dfr2);
 
         try {
-            new DefaultLightblueBulkDataResponse(jsonResponseWithError, null, bulkRequest);
+            new DefaultLightblueBulkDataResponse(jsonResponseWithError, bulkRequest);
             fail();
         } catch (LightblueBulkResponseException e) {
             //expected
@@ -234,12 +234,12 @@ public class TestDefaultLightblueBulkDataResponse {
 
     @Test(expected = LightblueParseException.class)
     public void testConstructor_With_NonArrayResponses() throws Exception {
-        new DefaultLightblueBulkDataResponse("{\"responses\":\"notAnArray\"}", null, new DataBulkRequest());
+        new DefaultLightblueBulkDataResponse("{\"responses\":\"notAnArray\"}", new DataBulkRequest());
     }
 
     @Test(expected = LightblueParseException.class)
     public void testConstructor_With_NonNumericSeq() throws Exception {
-        new DefaultLightblueBulkDataResponse("{\"responses\":[{\"seq\":\"notint\",\"response\":{}}]}", null, new DataBulkRequest());
+        new DefaultLightblueBulkDataResponse("{\"responses\":[{\"seq\":\"notint\",\"response\":{}}]}", new DataBulkRequest());
     }
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/response/TestDefaultLightblueBulkDataResponse.java
+++ b/core/src/test/java/com/redhat/lightblue/client/response/TestDefaultLightblueBulkDataResponse.java
@@ -53,7 +53,7 @@ public class TestDefaultLightblueBulkDataResponse {
         bulkRequest.add(dfr);
         bulkRequest.add(dfr2);
 
-        return new DefaultLightblueBulkDataResponse(jsonResponse, bulkRequest);
+        return new DefaultLightblueBulkDataResponse(jsonResponse, null, bulkRequest);
     }
 
     @Test
@@ -101,7 +101,7 @@ public class TestDefaultLightblueBulkDataResponse {
         bulkRequest.add(dfr2);
 
         try {
-            new DefaultLightblueBulkDataResponse(jsonResponseWithError, bulkRequest);
+            new DefaultLightblueBulkDataResponse(jsonResponseWithError, null, bulkRequest);
             fail();
         } catch (LightblueBulkResponseException e) {
             //expected
@@ -147,7 +147,7 @@ public class TestDefaultLightblueBulkDataResponse {
         bulkRequest.add(dfr2);
 
         try {
-            new DefaultLightblueBulkDataResponse(jsonResponseWithError, bulkRequest);
+            new DefaultLightblueBulkDataResponse(jsonResponseWithError, null, bulkRequest);
             fail();
         } catch (LightblueBulkResponseException e) {
             //expected
@@ -196,7 +196,7 @@ public class TestDefaultLightblueBulkDataResponse {
         bulkRequest.add(dfr2);
 
         try {
-            new DefaultLightblueBulkDataResponse(jsonResponseWithError, bulkRequest);
+            new DefaultLightblueBulkDataResponse(jsonResponseWithError, null, bulkRequest);
             fail();
         } catch (LightblueBulkResponseException e) {
             //expected
@@ -229,17 +229,17 @@ public class TestDefaultLightblueBulkDataResponse {
 
     @Test(expected = LightblueParseException.class)
     public void testConstructor_With_UnexpectedJson() throws Exception {
-        new DefaultLightblueBulkDataResponse("{}", new DataBulkRequest());
+        new DefaultLightblueBulkDataResponse("{}", null, new DataBulkRequest());
     }
 
     @Test(expected = LightblueParseException.class)
     public void testConstructor_With_NonArrayResponses() throws Exception {
-        new DefaultLightblueBulkDataResponse("{\"responses\":\"notAnArray\"}", new DataBulkRequest());
+        new DefaultLightblueBulkDataResponse("{\"responses\":\"notAnArray\"}", null, new DataBulkRequest());
     }
 
     @Test(expected = LightblueParseException.class)
     public void testConstructor_With_NonNumericSeq() throws Exception {
-        new DefaultLightblueBulkDataResponse("{\"responses\":[{\"seq\":\"notint\",\"response\":{}}]}", new DataBulkRequest());
+        new DefaultLightblueBulkDataResponse("{\"responses\":[{\"seq\":\"notint\",\"response\":{}}]}", null, new DataBulkRequest());
     }
 
 }

--- a/core/src/test/java/com/redhat/lightblue/client/response/TestDefaultLightblueDataResponse.java
+++ b/core/src/test/java/com/redhat/lightblue/client/response/TestDefaultLightblueDataResponse.java
@@ -27,7 +27,7 @@ public class TestDefaultLightblueDataResponse {
     @Test(expected = NullPointerException.class)
     public void testConstructor_NullObjectMapper() throws Exception {
         ObjectMapper om = null;
-        new DefaultLightblueDataResponse("{}", om);
+        new DefaultLightblueDataResponse("{}", null, om);
     }
 
     @Test

--- a/http/src/main/java/com/redhat/lightblue/client/http/LightblueHttpClient.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/LightblueHttpClient.java
@@ -21,6 +21,7 @@ import com.redhat.lightblue.client.Locking;
 import com.redhat.lightblue.client.PropertiesLightblueClientConfiguration;
 import com.redhat.lightblue.client.http.transport.HttpTransport;
 import com.redhat.lightblue.client.http.transport.JavaNetHttpTransport;
+import com.redhat.lightblue.client.http.transport.Response;
 import com.redhat.lightblue.client.request.DataBulkRequest;
 import com.redhat.lightblue.client.request.LightblueDataRequest;
 import com.redhat.lightblue.client.request.LightblueMetadataRequest;
@@ -90,8 +91,8 @@ public class LightblueHttpClient implements LightblueClient, Closeable {
         public boolean acquire(String callerId, String resourceId, Long ttl)
                 throws LightblueParseException, LightblueHttpClientException, LightblueResponseException, LightblueException {
             LightblueRequest req = new LockingRequest(getDomain(), callerId, resourceId, ttl, false, HttpMethod.PUT);
-            LockResponse response = new LockResponse(
-                    callService(req, configuration.getDataServiceURI()));
+            Response r = callService(req, configuration.getDataServiceURI());
+            LockResponse response = new LockResponse(r.getBody(), r.getHeaders());
 
             if (response.getJson() != null) {
                 return response.parseAsBoolean();
@@ -104,8 +105,8 @@ public class LightblueHttpClient implements LightblueClient, Closeable {
         public boolean release(String callerId, String resourceId)
                 throws LightblueParseException, LightblueHttpClientException, LightblueResponseException, LightblueException {
             LightblueRequest req = new LockingRequest(getDomain(), callerId, resourceId, null, false, HttpMethod.DELETE);
-            LockResponse response = new LockResponse(
-                    callService(req, configuration.getDataServiceURI()));
+            Response r = callService(req, configuration.getDataServiceURI());
+            LockResponse response = new LockResponse(r.getBody(), r.getHeaders());
 
             if (response.getJson() != null) {
                 return response.parseAsBoolean();
@@ -118,8 +119,8 @@ public class LightblueHttpClient implements LightblueClient, Closeable {
         public int getLockCount(String callerId, String resourceId)
                 throws LightblueParseException, LightblueHttpClientException, LightblueResponseException, LightblueException {
             LightblueRequest req = new LockingRequest(getDomain(), callerId, resourceId, null, false, HttpMethod.GET);
-            LockResponse response = new LockResponse(
-                    callService(req, configuration.getDataServiceURI()));
+            Response r = callService(req, configuration.getDataServiceURI());
+            LockResponse response = new LockResponse(r.getBody(), r.getHeaders());
 
             if (response.getJson() != null) {
                 return response.parseAsInt();
@@ -132,8 +133,8 @@ public class LightblueHttpClient implements LightblueClient, Closeable {
         public boolean ping(String callerId, String resourceId)
                 throws LightblueParseException, LightblueHttpClientException, LightblueResponseException, LightblueException {
             LightblueRequest req = new LockingRequest(getDomain(), callerId, resourceId, null, true, HttpMethod.PUT);
-            LockResponse response = new LockResponse(
-                    callService(req, configuration.getDataServiceURI()));
+            Response r = callService(req, configuration.getDataServiceURI());
+            LockResponse response = new LockResponse(r.getBody(), r.getHeaders());
 
             if (response.getJson() != null) {
                 return response.parseAsBoolean();
@@ -211,8 +212,10 @@ public class LightblueHttpClient implements LightblueClient, Closeable {
      */
     @Override
     public DefaultLightblueMetadataResponse metadata(LightblueMetadataRequest lightblueRequest) throws LightblueParseException, LightblueResponseException, LightblueHttpClientException, LightblueException {
+        Response response = callService(lightblueRequest, configuration.getDataServiceURI());
         return new DefaultLightblueMetadataResponse(
-                callService(lightblueRequest, configuration.getMetadataServiceURI()),
+                response.getBody(),
+                response.getHeaders(),
                 mapper);
     }
 
@@ -228,8 +231,10 @@ public class LightblueHttpClient implements LightblueClient, Closeable {
             lightblueRequest.execution(configuration.getExecution());
         }
 
+        Response response = callService(lightblueRequest, configuration.getDataServiceURI());
         return new DefaultLightblueDataResponse(
-                callService(lightblueRequest, configuration.getDataServiceURI()),
+                response.getBody(),
+                response.getHeaders(),
                 mapper);
     }
 
@@ -243,10 +248,14 @@ public class LightblueHttpClient implements LightblueClient, Closeable {
 
     @Override
     public DefaultLightblueBulkDataResponse bulkData(DataBulkRequest lightblueRequests) throws LightblueHttpClientException, LightblueBulkResponseException, LightblueParseException, LightblueException {
-        String response = callService(lightblueRequests, configuration.getDataServiceURI());
+        Response response = callService(lightblueRequests, configuration.getDataServiceURI());
 
         try {
-            return new DefaultLightblueBulkDataResponse(response, mapper, lightblueRequests);
+            return new DefaultLightblueBulkDataResponse(
+                    response.getBody(),
+                    response.getHeaders(),
+                    mapper,
+                    lightblueRequests);
         } catch (LightblueParseException e) {
             throw new LightblueParseException("Unable to parse response " + response, e);
         }
@@ -257,17 +266,17 @@ public class LightblueHttpClient implements LightblueClient, Closeable {
         httpTransport.close();
     }
 
-    protected String callService(LightblueRequest request, String baseUri) throws LightblueHttpClientException {
+    protected Response callService(LightblueRequest request, String baseUri) throws LightblueHttpClientException {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Calling service: {}", request.toString());
         }
 
         long t1 = System.currentTimeMillis();
 
-        String responseBody = httpTransport.executeRequest(request, baseUri);
+        Response response = httpTransport.executeRequest(request, baseUri);
 
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Response received from service: {}", responseBody);
+            LOGGER.debug("Response received from service: {}", response.getBody());
         }
 
         long t2 = new Date().getTime();
@@ -275,7 +284,7 @@ public class LightblueHttpClient implements LightblueClient, Closeable {
             LOGGER.debug("Call took {}ms", t2 - t1);
         }
 
-        return responseBody;
+        return response;
     }
 
     private static HttpTransport defaultHttpClientFromConfig(LightblueClientConfiguration config) {

--- a/http/src/main/java/com/redhat/lightblue/client/http/LightblueHttpClient.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/LightblueHttpClient.java
@@ -21,7 +21,7 @@ import com.redhat.lightblue.client.Locking;
 import com.redhat.lightblue.client.PropertiesLightblueClientConfiguration;
 import com.redhat.lightblue.client.http.transport.HttpTransport;
 import com.redhat.lightblue.client.http.transport.JavaNetHttpTransport;
-import com.redhat.lightblue.client.http.transport.Response;
+import com.redhat.lightblue.client.http.transport.HttpResponse;
 import com.redhat.lightblue.client.request.DataBulkRequest;
 import com.redhat.lightblue.client.request.LightblueDataRequest;
 import com.redhat.lightblue.client.request.LightblueMetadataRequest;
@@ -91,7 +91,7 @@ public class LightblueHttpClient implements LightblueClient, Closeable {
         public boolean acquire(String callerId, String resourceId, Long ttl)
                 throws LightblueParseException, LightblueHttpClientException, LightblueResponseException, LightblueException {
             LightblueRequest req = new LockingRequest(getDomain(), callerId, resourceId, ttl, false, HttpMethod.PUT);
-            Response r = callService(req, configuration.getDataServiceURI());
+            HttpResponse r = callService(req, configuration.getDataServiceURI());
             LockResponse response = new LockResponse(r.getBody(), r.getHeaders());
 
             if (response.getJson() != null) {
@@ -105,7 +105,7 @@ public class LightblueHttpClient implements LightblueClient, Closeable {
         public boolean release(String callerId, String resourceId)
                 throws LightblueParseException, LightblueHttpClientException, LightblueResponseException, LightblueException {
             LightblueRequest req = new LockingRequest(getDomain(), callerId, resourceId, null, false, HttpMethod.DELETE);
-            Response r = callService(req, configuration.getDataServiceURI());
+            HttpResponse r = callService(req, configuration.getDataServiceURI());
             LockResponse response = new LockResponse(r.getBody(), r.getHeaders());
 
             if (response.getJson() != null) {
@@ -119,7 +119,7 @@ public class LightblueHttpClient implements LightblueClient, Closeable {
         public int getLockCount(String callerId, String resourceId)
                 throws LightblueParseException, LightblueHttpClientException, LightblueResponseException, LightblueException {
             LightblueRequest req = new LockingRequest(getDomain(), callerId, resourceId, null, false, HttpMethod.GET);
-            Response r = callService(req, configuration.getDataServiceURI());
+            HttpResponse r = callService(req, configuration.getDataServiceURI());
             LockResponse response = new LockResponse(r.getBody(), r.getHeaders());
 
             if (response.getJson() != null) {
@@ -133,7 +133,7 @@ public class LightblueHttpClient implements LightblueClient, Closeable {
         public boolean ping(String callerId, String resourceId)
                 throws LightblueParseException, LightblueHttpClientException, LightblueResponseException, LightblueException {
             LightblueRequest req = new LockingRequest(getDomain(), callerId, resourceId, null, true, HttpMethod.PUT);
-            Response r = callService(req, configuration.getDataServiceURI());
+            HttpResponse r = callService(req, configuration.getDataServiceURI());
             LockResponse response = new LockResponse(r.getBody(), r.getHeaders());
 
             if (response.getJson() != null) {
@@ -212,7 +212,7 @@ public class LightblueHttpClient implements LightblueClient, Closeable {
      */
     @Override
     public DefaultLightblueMetadataResponse metadata(LightblueMetadataRequest lightblueRequest) throws LightblueParseException, LightblueResponseException, LightblueHttpClientException, LightblueException {
-        Response response = callService(lightblueRequest, configuration.getMetadataServiceURI());
+        HttpResponse response = callService(lightblueRequest, configuration.getMetadataServiceURI());
         return new DefaultLightblueMetadataResponse(
                 response.getBody(),
                 response.getHeaders(),
@@ -231,7 +231,7 @@ public class LightblueHttpClient implements LightblueClient, Closeable {
             lightblueRequest.execution(configuration.getExecution());
         }
 
-        Response response = callService(lightblueRequest, configuration.getDataServiceURI());
+        HttpResponse response = callService(lightblueRequest, configuration.getDataServiceURI());
         return new DefaultLightblueDataResponse(
                 response.getBody(),
                 response.getHeaders(),
@@ -248,7 +248,7 @@ public class LightblueHttpClient implements LightblueClient, Closeable {
 
     @Override
     public DefaultLightblueBulkDataResponse bulkData(DataBulkRequest lightblueRequests) throws LightblueHttpClientException, LightblueBulkResponseException, LightblueParseException, LightblueException {
-        Response response = callService(lightblueRequests, configuration.getDataServiceURI());
+        HttpResponse response = callService(lightblueRequests, configuration.getDataServiceURI());
 
         try {
             return new DefaultLightblueBulkDataResponse(
@@ -266,14 +266,14 @@ public class LightblueHttpClient implements LightblueClient, Closeable {
         httpTransport.close();
     }
 
-    protected Response callService(LightblueRequest request, String baseUri) throws LightblueHttpClientException {
+    protected HttpResponse callService(LightblueRequest request, String baseUri) throws LightblueHttpClientException {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Calling service: {}", request.toString());
         }
 
         long t1 = System.currentTimeMillis();
 
-        Response response = httpTransport.executeRequest(request, baseUri);
+        HttpResponse response = httpTransport.executeRequest(request, baseUri);
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Response received from service: {}", response.getBody());

--- a/http/src/main/java/com/redhat/lightblue/client/http/LightblueHttpClient.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/LightblueHttpClient.java
@@ -212,7 +212,7 @@ public class LightblueHttpClient implements LightblueClient, Closeable {
      */
     @Override
     public DefaultLightblueMetadataResponse metadata(LightblueMetadataRequest lightblueRequest) throws LightblueParseException, LightblueResponseException, LightblueHttpClientException, LightblueException {
-        Response response = callService(lightblueRequest, configuration.getDataServiceURI());
+        Response response = callService(lightblueRequest, configuration.getMetadataServiceURI());
         return new DefaultLightblueMetadataResponse(
                 response.getBody(),
                 response.getHeaders(),

--- a/http/src/main/java/com/redhat/lightblue/client/http/transport/HttpResponse.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/transport/HttpResponse.java
@@ -4,12 +4,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class Response {
+public class HttpResponse {
 
     private final Map<String, List<String>> headers;
     private final String body;
 
-    protected Response(final String body, final Map<String, List<String>> headers) {
+    protected HttpResponse(final String body, final Map<String, List<String>> headers) {
         this.body = body;
         this.headers = headers;
     }

--- a/http/src/main/java/com/redhat/lightblue/client/http/transport/HttpTransport.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/transport/HttpTransport.java
@@ -6,5 +6,7 @@ import com.redhat.lightblue.client.http.LightblueHttpClientException;
 import com.redhat.lightblue.client.request.LightblueRequest;
 
 public interface HttpTransport extends Closeable {
-    String executeRequest(LightblueRequest request, String baseUri) throws LightblueHttpClientException;
+
+    Response executeRequest(LightblueRequest request, String baseUri) throws LightblueHttpClientException;
+
 }

--- a/http/src/main/java/com/redhat/lightblue/client/http/transport/HttpTransport.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/transport/HttpTransport.java
@@ -7,6 +7,6 @@ import com.redhat.lightblue.client.request.LightblueRequest;
 
 public interface HttpTransport extends Closeable {
 
-    Response executeRequest(LightblueRequest request, String baseUri) throws LightblueHttpClientException;
+    HttpResponse executeRequest(LightblueRequest request, String baseUri) throws LightblueHttpClientException;
 
 }

--- a/http/src/main/java/com/redhat/lightblue/client/http/transport/JavaNetHttpTransport.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/transport/JavaNetHttpTransport.java
@@ -101,7 +101,7 @@ public class JavaNetHttpTransport implements HttpTransport {
     }
 
     @Override
-    public Response executeRequest(LightblueRequest request, String baseUri) throws LightblueHttpClientException {
+    public HttpResponse executeRequest(LightblueRequest request, String baseUri) throws LightblueHttpClientException {
         try {
             String url = request.getRestURI(baseUri);
             LOGGER.debug("Executing request, url={}", url);
@@ -129,7 +129,7 @@ public class JavaNetHttpTransport implements HttpTransport {
                 sendRequestBody(body, connection);
             }
 
-            return new Response(response(connection), connection.getHeaderFields());
+            return new HttpResponse(response(connection), connection.getHeaderFields());
         } catch (ProtocolException e) {
             throw new LightblueHttpClientException(e);
         } catch (IOException e) {

--- a/http/src/main/java/com/redhat/lightblue/client/http/transport/JavaNetHttpTransport.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/transport/JavaNetHttpTransport.java
@@ -101,7 +101,7 @@ public class JavaNetHttpTransport implements HttpTransport {
     }
 
     @Override
-    public String executeRequest(LightblueRequest request, String baseUri) throws LightblueHttpClientException {
+    public Response executeRequest(LightblueRequest request, String baseUri) throws LightblueHttpClientException {
         try {
             String url = request.getRestURI(baseUri);
             LOGGER.debug("Executing request, url={}", url);
@@ -129,7 +129,7 @@ public class JavaNetHttpTransport implements HttpTransport {
                 sendRequestBody(body, connection);
             }
 
-            return response(connection);
+            return new Response(response(connection), connection.getHeaderFields());
         } catch (ProtocolException e) {
             throw new LightblueHttpClientException(e);
         } catch (IOException e) {

--- a/http/src/main/java/com/redhat/lightblue/client/http/transport/Response.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/transport/Response.java
@@ -1,0 +1,28 @@
+package com.redhat.lightblue.client.http.transport;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Response {
+
+    private final Map<String, List<String>> headers;
+    private final String body;
+
+    protected Response(final String body, final Map<String, List<String>> headers) {
+        this.body = body;
+        this.headers = headers;
+    }
+
+    public Map<String, List<String>> getHeaders() {
+        if (headers == null) {
+            return null;
+        }
+        return new HashMap<>(headers);
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+}

--- a/http/src/test/java/com/redhat/lightblue/client/http/LightblueHttpClientTest.java
+++ b/http/src/test/java/com/redhat/lightblue/client/http/LightblueHttpClientTest.java
@@ -19,7 +19,7 @@ import com.redhat.lightblue.client.Projection;
 import com.redhat.lightblue.client.Query;
 import com.redhat.lightblue.client.http.model.SimpleModelObject;
 import com.redhat.lightblue.client.http.transport.HttpTransport;
-import com.redhat.lightblue.client.http.transport.Response;
+import com.redhat.lightblue.client.http.transport.HttpResponse;
 import com.redhat.lightblue.client.request.LightblueRequest;
 import com.redhat.lightblue.client.request.data.DataFindRequest;
 import com.redhat.lightblue.client.request.data.GenerateRequest;
@@ -187,7 +187,7 @@ public class LightblueHttpClientTest {
         }
     }
 
-    private static class FakeResponse extends Response {
+    private static class FakeResponse extends HttpResponse {
 
         protected FakeResponse(String body, Map<String, List<String>> headers) {
             super(body, headers);

--- a/http/src/test/java/com/redhat/lightblue/client/http/LightblueHttpClientTest.java
+++ b/http/src/test/java/com/redhat/lightblue/client/http/LightblueHttpClientTest.java
@@ -5,6 +5,9 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -16,6 +19,7 @@ import com.redhat.lightblue.client.Projection;
 import com.redhat.lightblue.client.Query;
 import com.redhat.lightblue.client.http.model.SimpleModelObject;
 import com.redhat.lightblue.client.http.transport.HttpTransport;
+import com.redhat.lightblue.client.http.transport.Response;
 import com.redhat.lightblue.client.request.LightblueRequest;
 import com.redhat.lightblue.client.request.data.DataFindRequest;
 import com.redhat.lightblue.client.request.data.GenerateRequest;
@@ -38,7 +42,7 @@ public class LightblueHttpClientTest {
 
         String response = "{\"matchCount\": 1, \"modifiedCount\": 0, \"processed\": [{\"_id\": \"idhash\", \"field\":\"value\"}], \"status\": \"COMPLETE\"}";
 
-        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString())).thenReturn(response);
+        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString())).thenReturn(new FakeResponse(response, null));
 
         SimpleModelObject[] results = client.data(findRequest, SimpleModelObject[].class);
 
@@ -52,7 +56,7 @@ public class LightblueHttpClientTest {
         GenerateRequest request = new GenerateRequest("foo", "bar");
         request.path("x").nValues(3);
         String response = "{ \"processed\": [\"1\",\"2\",\"3\"], \"status\": \"COMPLETE\"}";
-        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString())).thenReturn(response);
+        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString())).thenReturn(new FakeResponse(response, null));
 
         String[] results = client.data(request, String[].class);
 
@@ -71,7 +75,7 @@ public class LightblueHttpClientTest {
 
         String response = "{\"processed\":\"<p>This is not json</p>\"}";
 
-        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString())).thenReturn(response);
+        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString())).thenReturn(new FakeResponse(response, null));
 
         client.data(findRequest, SimpleModelObject[].class);
     }
@@ -94,14 +98,14 @@ public class LightblueHttpClientTest {
 
     @Test(expected = LightblueParseException.class)
     public void testParseInvalidJson() throws Exception {
-        DefaultLightblueDataResponse r = new DefaultLightblueDataResponse("invalid json", JSON.getDefaultObjectMapper());
+        DefaultLightblueDataResponse r = new DefaultLightblueDataResponse("invalid json", null, JSON.getDefaultObjectMapper());
 
         r.parseProcessed(SimpleModelObject.class);
     }
 
     @Test
     public void testUsingDefaultExecution_ReadPreference() throws Exception {
-        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString())).thenReturn("{}");
+        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString())).thenReturn(new FakeResponse("{}", null));
 
         LightblueClientConfiguration c = new LightblueClientConfiguration();
         c.setReadPreference(ReadPreference.primary);
@@ -121,7 +125,7 @@ public class LightblueHttpClientTest {
 
     @Test
     public void testUsingDefaultExecution_WriteConcern() throws Exception {
-        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString())).thenReturn("{}");
+        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString())).thenReturn(new FakeResponse("{}", null));
 
         LightblueClientConfiguration c = new LightblueClientConfiguration();
         c.setWriteConcern("majority");
@@ -141,7 +145,7 @@ public class LightblueHttpClientTest {
 
     @Test
     public void testUsingDefaultExecution_MaxQueryTimeMS() throws Exception {
-        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString())).thenReturn("{}");
+        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString())).thenReturn(new FakeResponse("{}", null));
 
         LightblueClientConfiguration c = new LightblueClientConfiguration();
         c.setMaxQueryTimeMS(1000);
@@ -164,7 +168,7 @@ public class LightblueHttpClientTest {
      */
     @Test
     public void testUsingDefaultExecution_OverrideExecution() throws Exception {
-        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString())).thenReturn("{}");
+        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString())).thenReturn(new FakeResponse("{}", null));
 
         LightblueClientConfiguration c = new LightblueClientConfiguration();
         c.setReadPreference(ReadPreference.primary);
@@ -181,6 +185,14 @@ public class LightblueHttpClientTest {
             Assert.assertTrue(body.contains(
                     "\"execution\":{\"readPreference\":\"nearest\"}"));
         }
+    }
+
+    private static class FakeResponse extends Response {
+
+        protected FakeResponse(String body, Map<String, List<String>> headers) {
+            super(body, headers);
+        }
+
     }
 
 }

--- a/http/src/test/java/com/redhat/lightblue/client/http/transport/JavaNetHttpTransportCompressionTest.java
+++ b/http/src/test/java/com/redhat/lightblue/client/http/transport/JavaNetHttpTransportCompressionTest.java
@@ -84,7 +84,7 @@ public class JavaNetHttpTransportCompressionTest {
 
         when(mockConnection.getInputStream()).thenReturn(inResponseBody);
 
-        String response = client.executeRequest(request, "");
+        String response = client.executeRequest(request, "").getBody();
 
         Assert.assertEquals(TEST_RESPONSE, response);
     }

--- a/http/src/test/java/com/redhat/lightblue/client/http/transport/JavaNetHttpTransportIntegrationTest.java
+++ b/http/src/test/java/com/redhat/lightblue/client/http/transport/JavaNetHttpTransportIntegrationTest.java
@@ -40,7 +40,7 @@ public class JavaNetHttpTransportIntegrationTest {
 
         LightblueRequest request = new FakeLightblueRequest("", HttpMethod.GET, "/");
 
-        String response = client.executeRequest(request, wireMockUrl());
+        String response = client.executeRequest(request, wireMockUrl()).getBody();
 
         assertThat(response, is("The body"));
     }
@@ -52,7 +52,7 @@ public class JavaNetHttpTransportIntegrationTest {
 
         LightblueRequest request = new FakeLightblueRequest("", HttpMethod.GET, "/");
 
-        Assert.assertEquals("The body", client.executeRequest(request, wireMockUrl()));
+        Assert.assertEquals("The body", client.executeRequest(request, wireMockUrl()).getBody());
     }
 
     @Test

--- a/http/src/test/java/com/redhat/lightblue/client/http/transport/JavaNetHttpTransportTest.java
+++ b/http/src/test/java/com/redhat/lightblue/client/http/transport/JavaNetHttpTransportTest.java
@@ -162,7 +162,7 @@ public class JavaNetHttpTransportTest {
         responseStream.print(konnichiWa);
         when(mockConnection.getContentLength()).thenReturn(konnichiWa.getBytes("UTF-8").length);
 
-        assertThat(client.executeRequest(helloInJapanese, ""), is(konnichiWa));
+        assertThat(client.executeRequest(helloInJapanese, "").getBody(), is(konnichiWa));
     }
 
     @Test(timeout = 500)
@@ -175,7 +175,7 @@ public class JavaNetHttpTransportTest {
         responseStream.close();
         when(mockConnection.getContentLength()).thenReturn(-1);
 
-        assertThat(client.executeRequest(helloInJapanese, ""), is(konnichiWa));
+        assertThat(client.executeRequest(helloInJapanese, "").getBody(), is(konnichiWa));
     }
 
     @Test(timeout = 500)
@@ -184,7 +184,7 @@ public class JavaNetHttpTransportTest {
 
         when(mockConnection.getContentLength()).thenReturn(0);
 
-        assertThat(client.executeRequest(getFooBar, ""), is(""));
+        assertThat(client.executeRequest(getFooBar, "").getBody(), is(""));
     }
 
     @Test(timeout = 500)
@@ -197,7 +197,7 @@ public class JavaNetHttpTransportTest {
         errorResponseStream.print(error);
         when(mockConnection.getContentLength()).thenReturn(error.getBytes("UTF-8").length);
 
-        Assert.assertEquals(error, client.executeRequest(badHelloRequest, ""));
+        Assert.assertEquals(error, client.executeRequest(badHelloRequest, "").getBody());
     }
 
     @Test(timeout = 500)
@@ -211,7 +211,7 @@ public class JavaNetHttpTransportTest {
         errorResponseStream.close();
         when(mockConnection.getContentLength()).thenReturn(-1);
 
-        Assert.assertEquals(error, client.executeRequest(badHelloRequest, ""));
+        Assert.assertEquals(error, client.executeRequest(badHelloRequest, "").getBody());
     }
 
     @Test(timeout = 500)

--- a/lightblue-client-integration-test/src/test/java/com/redhat/lightblue/client/integration/test/CountryDAOTest.java
+++ b/lightblue-client-integration-test/src/test/java/com/redhat/lightblue/client/integration/test/CountryDAOTest.java
@@ -11,7 +11,9 @@ import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.redhat.lightblue.client.LightblueException;
@@ -25,6 +27,7 @@ import com.redhat.lightblue.client.request.data.DataInsertRequest;
 import com.redhat.lightblue.client.response.LightblueBulkDataResponse;
 import com.redhat.lightblue.client.response.LightblueDataResponse;
 import com.redhat.lightblue.client.response.LightblueParseException;
+import com.redhat.lightblue.client.response.LightblueResponseException;
 
 /**
  * Testing your code against lightblue example.
@@ -33,6 +36,9 @@ import com.redhat.lightblue.client.response.LightblueParseException;
  *
  */
 public class CountryDAOTest extends LightblueClientTestHarness {
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
 
     private LightblueHttpClient client;
 
@@ -161,6 +167,20 @@ public class CountryDAOTest extends LightblueClientTestHarness {
 
         assertNotNull(versions);
         assertTrue(versions.isEmpty());
+    }
+
+    /**
+     * Verifies that the RequestID header is included in the exception message.
+     */
+    @Test
+    public void testRequestHeader() throws Exception {
+        exception.expect(LightblueResponseException.class);
+        exception.expectMessage("RequestID:");
+
+        DataFindRequest request = new DataFindRequest("fake");
+        request.where(Query.withValue("_id", Query.eq, "abc"));
+
+        client.data(request);
     }
 
 }


### PR DESCRIPTION
Makes headers available to client applications and also includes the RequestID in the error message.