### PR TITLE
Fixes #328: Allow injecting mapper used for request serialization

### DIFF
--- a/core/src/main/java/com/redhat/lightblue/client/request/CRUDRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/CRUDRequest.java
@@ -1,9 +1,5 @@
 package com.redhat.lightblue.client.request;
 
-import org.apache.commons.lang.StringUtils;
-
-import com.fasterxml.jackson.databind.JsonNode;
-
 import com.redhat.lightblue.client.http.HttpMethod;
 import com.redhat.lightblue.client.Operation;
 

--- a/core/src/main/java/com/redhat/lightblue/client/request/LightblueRequest.java
+++ b/core/src/main/java/com/redhat/lightblue/client/request/LightblueRequest.java
@@ -39,6 +39,7 @@ public abstract class LightblueRequest implements Serializable {
     /**
      * Requst body as string, defaults to getBodyJson().toString()
      */
+    @Deprecated
     public String getBody() {
         JsonNode body=getBodyJson();
         if(body!=null) {

--- a/http/src/main/java/com/redhat/lightblue/client/http/LightblueHttpClient.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/LightblueHttpClient.java
@@ -275,7 +275,7 @@ public class LightblueHttpClient implements LightblueClient, Closeable {
 
         long t1 = System.currentTimeMillis();
 
-        HttpResponse response = httpTransport.executeRequest(request, baseUri);
+        HttpResponse response = httpTransport.executeRequest(request, baseUri, mapper);
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Response received from service: {}", response.getBody());

--- a/http/src/main/java/com/redhat/lightblue/client/http/transport/HttpTransport.java
+++ b/http/src/main/java/com/redhat/lightblue/client/http/transport/HttpTransport.java
@@ -5,8 +5,9 @@ import java.io.Closeable;
 import com.redhat.lightblue.client.http.LightblueHttpClientException;
 import com.redhat.lightblue.client.request.LightblueRequest;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 public interface HttpTransport extends Closeable {
-
-    HttpResponse executeRequest(LightblueRequest request, String baseUri) throws LightblueHttpClientException;
-
+    HttpResponse executeRequest(LightblueRequest request, String baseUri, ObjectMapper mapper)
+            throws LightblueHttpClientException;
 }

--- a/http/src/test/java/com/redhat/lightblue/client/http/LightblueHttpClientTest.java
+++ b/http/src/test/java/com/redhat/lightblue/client/http/LightblueHttpClientTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -42,7 +43,8 @@ public class LightblueHttpClientTest {
 
         String response = "{\"matchCount\": 1, \"modifiedCount\": 0, \"processed\": [{\"_id\": \"idhash\", \"field\":\"value\"}], \"status\": \"COMPLETE\"}";
 
-        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString())).thenReturn(new FakeResponse(response, null));
+        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString(), any(ObjectMapper.class)))
+                .thenReturn(new FakeResponse(response, null));
 
         SimpleModelObject[] results = client.data(findRequest, SimpleModelObject[].class);
 
@@ -56,7 +58,8 @@ public class LightblueHttpClientTest {
         GenerateRequest request = new GenerateRequest("foo", "bar");
         request.path("x").nValues(3);
         String response = "{ \"processed\": [\"1\",\"2\",\"3\"], \"status\": \"COMPLETE\"}";
-        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString())).thenReturn(new FakeResponse(response, null));
+        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString(), any(ObjectMapper.class)))
+                .thenReturn(new FakeResponse(response, null));
 
         String[] results = client.data(request, String[].class);
 
@@ -75,7 +78,8 @@ public class LightblueHttpClientTest {
 
         String response = "{\"processed\":\"<p>This is not json</p>\"}";
 
-        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString())).thenReturn(new FakeResponse(response, null));
+        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString(), any(ObjectMapper.class)))
+                .thenReturn(new FakeResponse(response, null));
 
         client.data(findRequest, SimpleModelObject[].class);
     }
@@ -105,7 +109,8 @@ public class LightblueHttpClientTest {
 
     @Test
     public void testUsingDefaultExecution_ReadPreference() throws Exception {
-        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString())).thenReturn(new FakeResponse("{}", null));
+        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString(), any(ObjectMapper.class)))
+                .thenReturn(new FakeResponse("{}", null));
 
         LightblueClientConfiguration c = new LightblueClientConfiguration();
         c.setReadPreference(ReadPreference.primary);
@@ -125,7 +130,8 @@ public class LightblueHttpClientTest {
 
     @Test
     public void testUsingDefaultExecution_WriteConcern() throws Exception {
-        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString())).thenReturn(new FakeResponse("{}", null));
+        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString(), any(ObjectMapper.class)))
+                .thenReturn(new FakeResponse("{}", null));
 
         LightblueClientConfiguration c = new LightblueClientConfiguration();
         c.setWriteConcern("majority");
@@ -145,7 +151,8 @@ public class LightblueHttpClientTest {
 
     @Test
     public void testUsingDefaultExecution_MaxQueryTimeMS() throws Exception {
-        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString())).thenReturn(new FakeResponse("{}", null));
+        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString(), any(ObjectMapper.class)))
+                .thenReturn(new FakeResponse("{}", null));
 
         LightblueClientConfiguration c = new LightblueClientConfiguration();
         c.setMaxQueryTimeMS(1000);
@@ -168,7 +175,8 @@ public class LightblueHttpClientTest {
      */
     @Test
     public void testUsingDefaultExecution_OverrideExecution() throws Exception {
-        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString())).thenReturn(new FakeResponse("{}", null));
+        when(httpTransport.executeRequest(any(LightblueRequest.class), anyString(), any(ObjectMapper.class)))
+                .thenReturn(new FakeResponse("{}", null));
 
         LightblueClientConfiguration c = new LightblueClientConfiguration();
         c.setReadPreference(ReadPreference.primary);

--- a/http/src/test/java/com/redhat/lightblue/client/http/testing/doubles/FakeLightblueRequest.java
+++ b/http/src/test/java/com/redhat/lightblue/client/http/testing/doubles/FakeLightblueRequest.java
@@ -23,7 +23,7 @@ public class FakeLightblueRequest extends LightblueRequest {
 
     @Override
     public JsonNode getBodyJson() {
-        return JSON.toJsonNode(body);
+        return body == null ? null : JSON.toJsonNode(body);
     }
 
     @Override

--- a/http/src/test/java/com/redhat/lightblue/client/http/transport/JavaNetHttpTransportCompressionTest.java
+++ b/http/src/test/java/com/redhat/lightblue/client/http/transport/JavaNetHttpTransportCompressionTest.java
@@ -12,6 +12,7 @@ import java.io.PipedOutputStream;
 import java.io.PrintWriter;
 import java.net.HttpURLConnection;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,6 +27,7 @@ import com.redhat.lightblue.client.http.LightblueHttpClientException;
 import com.redhat.lightblue.client.http.testing.doubles.FakeLightblueRequest;
 import com.redhat.lightblue.client.http.transport.JavaNetHttpTransportTest.CallConnectAndReturn;
 import com.redhat.lightblue.client.request.LightblueRequest;
+import com.redhat.lightblue.client.util.JSON;
 
 /**
  * Testing {@link JavaNetHttpTransport}'s lzf compression support.
@@ -35,6 +37,8 @@ import com.redhat.lightblue.client.request.LightblueRequest;
  */
 @RunWith(JUnit4.class)
 public class JavaNetHttpTransportCompressionTest {
+
+    private static final ObjectMapper mapper = JSON.getDefaultObjectMapper();
 
     private HttpURLConnection mockConnection = mock(HttpURLConnection.class);
     private JavaNetHttpTransport.ConnectionFactory mockConnectionFactory = mock(JavaNetHttpTransport.ConnectionFactory.class);
@@ -51,7 +55,7 @@ public class JavaNetHttpTransportCompressionTest {
     public void shouldSetAcceptEncodingHeaderToLzfByDefault() throws LightblueHttpClientException {
         LightblueRequest request = new FakeLightblueRequest("", HttpMethod.GET, "/foo/bar");
 
-        client.executeRequest(request, "");
+        client.executeRequest(request, "", mapper);
 
         Mockito.verify(mockConnection).setRequestProperty("Accept-Encoding", "lzf");
     }
@@ -61,7 +65,7 @@ public class JavaNetHttpTransportCompressionTest {
         LightblueRequest request = new FakeLightblueRequest("", HttpMethod.GET, "/foo/bar");
 
         client.setCompression(Compression.NONE);
-        client.executeRequest(request, "");
+        client.executeRequest(request, "", mapper);
 
         Mockito.verify(mockConnection, never()).setRequestProperty(Mockito.eq("Accept-Encoding"), Mockito.anyString());
     }
@@ -84,7 +88,7 @@ public class JavaNetHttpTransportCompressionTest {
 
         when(mockConnection.getInputStream()).thenReturn(inResponseBody);
 
-        String response = client.executeRequest(request, "").getBody();
+        String response = client.executeRequest(request, "", mapper).getBody();
 
         Assert.assertEquals(TEST_RESPONSE, response);
     }


### PR DESCRIPTION
#328 

TODO:

- [ ] Does removing the content length header from request prevent persistent connections?