### PR TITLE
Update(pojo)

### DIFF
--- a/core/src/main/java/com/redhat/lightblue/client/Update.java
+++ b/core/src/main/java/com/redhat/lightblue/client/Update.java
@@ -2,6 +2,7 @@ package com.redhat.lightblue.client;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -225,9 +226,15 @@ public class Update extends Expression implements ForEachUpdate {
      * @param pojo
      * @return
      */
-    public static Update update(Object pojo) {
+    public static Update updatePojo(Object pojo) {
+      Objects.requireNonNull(pojo, "Pojo cannot be null");
+
       ObjectNode set = JsonNodeFactory.instance.objectNode();
-      set.set("$set", JSON.toJsonNode(pojo));
+      JsonNode pojoAsJson = JSON.toJsonNode(pojo);
+      if (!(pojoAsJson instanceof ObjectNode)) {
+        throw new IllegalArgumentException(pojo+" is not a pojo!");
+      }
+      set.set("$set", pojoAsJson);
       return new Update(set);
     }
 

--- a/core/src/main/java/com/redhat/lightblue/client/Update.java
+++ b/core/src/main/java/com/redhat/lightblue/client/Update.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ContainerNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.redhat.lightblue.client.util.JSON;
 
 /**
  * Update expression
@@ -216,6 +217,18 @@ public class Update extends Expression implements ForEachUpdate {
 
     public static Update update(ContainerNode node) {
         return new Update(node);
+    }
+
+    /**
+     * Creates an update like so: $set: toJson(pojo)
+     *
+     * @param pojo
+     * @return
+     */
+    public static Update update(Object pojo) {
+      ObjectNode set = JsonNodeFactory.instance.objectNode();
+      set.set("$set", JSON.toJsonNode(pojo));
+      return new Update(set);
     }
 
     /**

--- a/core/src/test/java/com/redhat/lightblue/client/ExpressionTest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/ExpressionTest.java
@@ -74,6 +74,22 @@ public class ExpressionTest {
         eq("{'$foreach': { 'x':{'field':'x','op':'=','rvalue':1},'$update':{'$set':{'y':2}}}}", Update.forEach("x", Query.withValue("x", Query.eq, 1), Update.set("y", 2)));
     }
 
+    class Pojo {
+      String foo = "bar";
+      int i = 13;
+      public String getFoo() {
+        return foo;
+      }
+      public int getI() {
+        return i;
+      }
+    }
+
+    @Test
+    public void updatePojoTest() throws Exception {
+      eq("{'$set':{'foo':'bar','i':13}}", Update.update(new Pojo()));
+    }
+
     @Test
     public void testNot() throws JSONException {
         Query testQueryExpression = Query.withValue("test", Query.BinOp.neq, "hack");

--- a/core/src/test/java/com/redhat/lightblue/client/ExpressionTest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/ExpressionTest.java
@@ -1,5 +1,7 @@
 package com.redhat.lightblue.client;
 
+import java.util.Arrays;
+
 import org.json.JSONException;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -86,8 +88,33 @@ public class ExpressionTest {
     }
 
     @Test
-    public void updatePojoTest() throws Exception {
-      eq("{'$set':{'foo':'bar','i':13}}", Update.update(new Pojo()));
+    public void updatePojoValidTest() throws Exception {
+      eq("{'$set':{'foo':'bar','i':13}}", Update.updatePojo(new Pojo()));
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void updatePojoInvalidStringTest() throws Exception {
+      Update.updatePojo("foo");
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void updatePojoInvalidPrimitiveTest() throws Exception {
+      Update.updatePojo(3);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void updatePojoInvalidArrayTest() throws Exception {
+      Update.updatePojo(new Pojo[] { new Pojo(), new Pojo()});
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void updatePojoInvalidListTest() throws Exception {
+      Update.updatePojo(Arrays.asList(new Pojo[] { new Pojo(), new Pojo()}));
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void updatePojoInvalidNullTest() throws Exception {
+      Update.updatePojo(null);
     }
 
     @Test


### PR DESCRIPTION
This is for "update all" use case. It's like save with upsert=true, except it will not make changes if no matching entity is found (instead of creating it, as upsert=true would).