### PR TITLE
Added SystemEnvironmentAwareProperties

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,4 +7,17 @@
   </parent>
   <version>5.12.0-SNAPSHOT</version><artifactId>lightblue-client-core</artifactId>
   <name>lightblue-client: ${project.groupId}|${project.artifactId}</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>1.7.0</version>
+     </dependency>
+     <dependency>
+       <groupId>org.powermock</groupId>
+       <artifactId>powermock-api-mockito</artifactId>
+       <version>1.7.0</version>
+     </dependency>
+  </dependencies>
 </project>

--- a/core/src/main/java/com/redhat/lightblue/client/PropertiesLightblueClientConfiguration.java
+++ b/core/src/main/java/com/redhat/lightblue/client/PropertiesLightblueClientConfiguration.java
@@ -153,7 +153,7 @@ public final class PropertiesLightblueClientConfiguration {
      */
     public static LightblueClientConfiguration fromInputStream(InputStream propertiesStream) {
         try {
-            Properties properties = new Properties();
+            Properties properties = new SystemEnvironmentAwareProperties();
             properties.load(loadInputStream(propertiesStream));
 
             return fromObject(properties);

--- a/core/src/main/java/com/redhat/lightblue/client/SystemEnvironmentAwareProperties.java
+++ b/core/src/main/java/com/redhat/lightblue/client/SystemEnvironmentAwareProperties.java
@@ -1,0 +1,68 @@
+package com.redhat.lightblue.client;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.util.Enumeration;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Extended Properties class for working with Strings that have placeholders for system environment variables in them.
+ * A placeholder takes the form ${env.NAME}.
+ *
+ * <p>
+ * Example: dataServiceURI=${env.LIGHTBLUE_DATA_SERVICE_URL}
+ * </p>
+ */
+public class SystemEnvironmentAwareProperties extends Properties {
+
+    private static final Pattern PROPERTY_PLACEHOLDER_PATTERN = Pattern.compile("\\$\\{env\\.(.*?)\\}");
+
+    @Override
+    public synchronized void load(Reader reader) throws IOException {
+        super.load(reader);
+        replacePlaceholders();
+    }
+
+    @Override
+    public synchronized void load(InputStream inStream) throws IOException {
+        super.load(inStream);
+        replacePlaceholders();
+    }
+
+    /**
+     * Loop through all properties and replace the placeholders of format ${env.NAME}
+     * with the corresponding property value from the system environment.
+     */
+    private synchronized void replacePlaceholders() {
+        for (Enumeration e = super.propertyNames() ; e.hasMoreElements() ;) {
+            String name = (String)e.nextElement() ;
+            super.setProperty(name, findAndReplacePlaceholders(super.getProperty(name)));
+        }
+    }
+
+
+    /**
+     * Replace placeholders in the provided value by the appropriate system environment variable, otherwise return the original value.
+     * Placeholder referencing non-existing system environment variables are replaced by an empty string.
+     *
+     * @param value The property value with or without property placeholders.
+     * @return the supplied value with placeholders replaced inline
+     */
+    private String findAndReplacePlaceholders(String value) {
+        if (value==null) {
+            return value;
+        }
+
+        Matcher matchPattern = PROPERTY_PLACEHOLDER_PATTERN.matcher(value);
+        StringBuffer sb = new StringBuffer();
+        while(matchPattern.find()) {
+            String environmentVariable = System.getenv(matchPattern.group(1));
+            matchPattern.appendReplacement(sb, environmentVariable!=null?Matcher.quoteReplacement(environmentVariable):"");
+        }
+        matchPattern.appendTail(sb);
+        return sb.toString();
+    }
+}

--- a/core/src/test/java/com/redhat/lightblue/client/PropertiesLightblueClientSystemEnvTest.java
+++ b/core/src/test/java/com/redhat/lightblue/client/PropertiesLightblueClientSystemEnvTest.java
@@ -1,0 +1,38 @@
+package com.redhat.lightblue.client;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by ykoer on 7/31/17.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({System.class, SystemEnvironmentAwareProperties.class})
+public class PropertiesLightblueClientSystemEnvTest {
+
+    @Test
+    public void shouldReplaceSystemEnvironmentPropertyPlaceholders() {
+
+        PowerMockito.mockStatic(System.class);
+        when(System.getenv("LB_DATA_SERVICE_URL")).thenReturn("http://this.is.a/test/data");
+        when(System.getenv("LB_METADATA_SERVICE_URL")).thenReturn("http://this.is.a/test/metadata");
+
+        Path resourceWithSystemEnvPlaceholders = Paths.get("lightblue-client-systemenv.properties");
+        LightblueClientConfiguration config = PropertiesLightblueClientConfiguration.fromPath(resourceWithSystemEnvPlaceholders);
+
+        assertEquals("http://this.is.a/test/data", config.getDataServiceURI());
+        assertEquals("http://this.is.a/test/metadata", config.getMetadataServiceURI());
+
+        // properties without placeholders should still work
+        assertEquals("certFile", config.getCertAlias());
+    }
+}

--- a/core/src/test/resources/lightblue-client-systemenv.properties
+++ b/core/src/test/resources/lightblue-client-systemenv.properties
@@ -1,0 +1,7 @@
+metadataServiceURI=${env.LB_METADATA_SERVICE_URL}
+dataServiceURI=${env.LB_DATA_SERVICE_URL}
+useCertAuth=true
+caFilePath=${env.LB_CACERT_FILE}
+certFilePath=${env.LB_CERT_FILE}
+certPassword=${env.LB_CERT_PASSWORD}
+certAlias=certFile


### PR DESCRIPTION
 to support system environment placeholders in the lightblue client configuration.

The rationale behind it is Openshift deployment. Configurations are usually passed in as System Environment variables.